### PR TITLE
#22 - Add in optimization for setting the lifetime of services 

### DIFF
--- a/src/ZCrew.Extensions.DependencyInjection.Registration/IServiceSource.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/IServiceSource.cs
@@ -7,4 +7,12 @@ namespace ZCrew.Extensions.DependencyInjection.Registration;
 ///     in the registration chain, providing the resulting <see cref="ServiceDescriptor"/> registrations as an
 ///     <see cref="IServiceCollection"/>.
 /// </summary>
-public interface IServiceSource : IServiceCollection;
+public interface IServiceSource : IServiceCollection
+{
+    /// <summary>
+    ///     Returns a new <see cref="IServiceSource"/> with all descriptors set to the specified
+    ///     <paramref name="lifetime"/>. Instance-based descriptors that cannot change lifetime are kept unchanged.
+    /// </summary>
+    /// <param name="lifetime">The target service lifetime.</param>
+    IServiceSource AsLifetime(ServiceLifetime lifetime);
+}

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceCollectionSource.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceCollectionSource.cs
@@ -17,4 +17,10 @@ public class ServiceCollectionSource : ServiceCollection, IServiceSource
         }
         MakeReadOnly();
     }
+
+    /// <inheritdoc />
+    IServiceSource IServiceSource.AsLifetime(ServiceLifetime lifetime)
+    {
+        return new ServiceCollectionSource(this.AsLifetime(lifetime));
+    }
 }

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceSelector.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceSelector.cs
@@ -113,12 +113,15 @@ public sealed class ServiceSelector : ServiceSource, IServiceSelector
     }
 
     /// <inheritdoc />
-    protected override IEnumerable<ServiceDescriptor> SelectServices()
+    protected override IEnumerable<ServiceDescriptor> SelectServices(ServiceLifetime lifetime)
     {
-        return AsSelf();
+        return SelectFromType(type => [type], lifetime);
     }
 
-    private KeyedServiceSelector SelectFromType(Func<Type, IEnumerable<Type>> serviceSelector)
+    private KeyedServiceSelector SelectFromType(
+        Func<Type, IEnumerable<Type>> serviceSelector,
+        ServiceLifetime lifetime = ServiceLifetime.Singleton
+    )
     {
         var descriptors = new LinkedList<ServiceDescriptor>();
         foreach (var type in this.types)
@@ -126,7 +129,7 @@ public sealed class ServiceSelector : ServiceSource, IServiceSelector
             var services = serviceSelector(type);
             foreach (var service in services)
             {
-                var descriptor = new ServiceDescriptor(service, type, ServiceLifetime.Singleton);
+                var descriptor = new ServiceDescriptor(service, type, lifetime);
                 descriptors.AddLast(descriptor);
             }
         }

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceSource.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceSource.cs
@@ -11,25 +11,33 @@ namespace ZCrew.Extensions.DependencyInjection.Registration;
 public abstract class ServiceSource : IServiceSource
 {
     private readonly LazyServiceCollection lazyServiceCollection;
+    private ServiceLifetime lifetime = ServiceLifetime.Singleton;
 
     /// <summary>
     ///     Initialize a new service source with a <see cref="lazyServiceCollection"/> backing it.
     /// </summary>
     protected ServiceSource()
     {
-        this.lazyServiceCollection = new LazyServiceCollection(SelectServices);
+        this.lazyServiceCollection = new LazyServiceCollection(() => SelectServices(this.lifetime));
     }
 
     /// <summary>
     ///     When overridden, produces the service descriptors for this node in the registration chain.
     /// </summary>
-    protected abstract IEnumerable<ServiceDescriptor> SelectServices();
+    protected abstract IEnumerable<ServiceDescriptor> SelectServices(ServiceLifetime lifetime);
 
     /// <inheritdoc />
     public ServiceDescriptor this[int index]
     {
         get => this.lazyServiceCollection[index];
         set => this.lazyServiceCollection[index] = value;
+    }
+
+    /// <inheritdoc />
+    public IServiceSource AsLifetime(ServiceLifetime lifetime)
+    {
+        this.lifetime = lifetime;
+        return this;
     }
 
     /// <inheritdoc />

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceSourceExtensions.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceSourceExtensions.cs
@@ -38,66 +38,11 @@ public static class ServiceSourceExtensions
 
         /// <summary>
         ///     Returns a new <see cref="IServiceSource"/> with all descriptors set to
-        ///     <see cref="ServiceLifetime.Scoped"/>.
-        /// </summary>
-        /// <param name="ignoreSingletonImplementations">
-        ///     When <see langword="true"/>, instance-based descriptors that can only be singletons are kept unchanged
-        ///     instead of throwing.
-        /// </param>
-        public IServiceSource AsScoped(bool ignoreSingletonImplementations)
-        {
-            return services.AsLifetime(ServiceLifetime.Scoped, ignoreSingletonImplementations);
-        }
-
-        /// <summary>
-        ///     Returns a new <see cref="IServiceSource"/> with all descriptors set to
         ///     <see cref="ServiceLifetime.Transient"/>.
         /// </summary>
         public IServiceSource AsTransient()
         {
             return services.AsLifetime(ServiceLifetime.Transient);
-        }
-
-        /// <summary>
-        ///     Returns a new <see cref="IServiceSource"/> with all descriptors set to
-        ///     <see cref="ServiceLifetime.Transient"/>.
-        /// </summary>
-        /// <param name="ignoreSingletonImplementations">
-        ///     When <see langword="true"/>, instance-based descriptors that can only be singletons are kept unchanged
-        ///     instead of throwing.
-        /// </param>
-        public IServiceSource AsTransient(bool ignoreSingletonImplementations)
-        {
-            return services.AsLifetime(ServiceLifetime.Transient, ignoreSingletonImplementations);
-        }
-
-        /// <summary>
-        ///     Returns a new <see cref="IServiceSource"/> with all descriptors set to the specified
-        ///     <paramref name="lifetime"/>. Instance-based descriptors that cannot change lifetime are kept unchanged.
-        /// </summary>
-        /// <param name="lifetime">The target service lifetime.</param>
-        public IServiceSource AsLifetime(ServiceLifetime lifetime)
-        {
-            return services.AsLifetime(lifetime, ignoreSingletonImplementations: true);
-        }
-
-        /// <summary>
-        ///     Returns a new <see cref="IServiceSource"/> with all descriptors set to the specified
-        ///     <paramref name="lifetime"/>.
-        /// </summary>
-        /// <param name="lifetime">The target service lifetime.</param>
-        /// <param name="ignoreSingletonImplementations">
-        ///     When <see langword="true"/>, instance-based descriptors that can only be singletons are kept unchanged
-        ///     instead of throwing.
-        /// </param>
-        public IServiceSource AsLifetime(ServiceLifetime lifetime, bool ignoreSingletonImplementations)
-        {
-            var modifiedServices = new ServiceDescriptor[services.Count];
-            for (var i = 0; i < services.Count; i++)
-            {
-                modifiedServices[i] = services[i].WithLifetime(lifetime, ignoreSingletonImplementations);
-            }
-            return new ServiceCollectionSource(modifiedServices);
         }
     }
 }

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/TypeFilter.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/TypeFilter.cs
@@ -103,12 +103,12 @@ public sealed class TypeFilter : ServiceSource, ITypeFilter
     }
 
     /// <inheritdoc />
-    protected override IEnumerable<ServiceDescriptor> SelectServices()
+    protected override IEnumerable<ServiceDescriptor> SelectServices(ServiceLifetime lifetime)
     {
         // Types have not yet been filtered by base types since new base types may be added
         // At this point the filtering should be applied since the service descriptors are being resolved
         return this
             .types.Where(type => this.baseTypes.Any(baseType => baseType.IsAssignableFrom(type)))
-            .Select(type => new ServiceDescriptor(type, type, ServiceLifetime.Singleton));
+            .Select(type => new ServiceDescriptor(type, type, lifetime));
     }
 }

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/TypeSelectorBase.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/TypeSelectorBase.cs
@@ -12,8 +12,8 @@ public abstract class TypeSelectorBase : ServiceSource, ITypeSelector
     public abstract IEnumerable<Type> SelectTypes();
 
     /// <inheritdoc />
-    protected override IEnumerable<ServiceDescriptor> SelectServices()
+    protected override IEnumerable<ServiceDescriptor> SelectServices(ServiceLifetime lifetime)
     {
-        return SelectTypes().Select(type => new ServiceDescriptor(type, type, ServiceLifetime.Singleton));
+        return SelectTypes().Select(type => new ServiceDescriptor(type, type, lifetime));
     }
 }

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.UnitTests/ServiceSourceExtensionsTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.UnitTests/ServiceSourceExtensionsTests.cs
@@ -23,21 +23,6 @@ public class ServiceSourceExtensionsTests
     }
 
     [Fact]
-    public void AsSingleton_WhenDescriptorsAlreadySingleton_ShouldReturnSameDescriptors()
-    {
-        // Arrange
-        var descriptor = ServiceDescriptor.Singleton<ICustomerService, CustomerService>();
-        var source = new ServiceCollectionSource([descriptor]);
-
-        // Act
-        var result = source.AsSingleton();
-
-        // Assert
-        var single = Assert.Single(result);
-        Assert.Same(descriptor, single);
-    }
-
-    [Fact]
     public void AsScoped_WhenCalled_ShouldReturnDescriptorsWithScopedLifetime()
     {
         // Arrange
@@ -52,38 +37,6 @@ public class ServiceSourceExtensionsTests
         // Assert
         var single = Assert.Single(result);
         Assert.Equal(ServiceLifetime.Scoped, single.Lifetime);
-    }
-
-    [Fact]
-    public void AsScoped_WhenIgnoreSingletonIsFalseAndInstanceDescriptor_ShouldThrow()
-    {
-        // Arrange
-        var source = new ServiceCollectionSource(
-        [
-            ServiceDescriptor.Singleton<ICustomerService>(new CustomerService()),
-        ]);
-
-        // Act
-        var act = () => source.AsScoped(ignoreSingletonImplementations: false);
-
-        // Assert
-        Assert.Throws<InvalidOperationException>(act);
-    }
-
-    [Fact]
-    public void AsScoped_WhenIgnoreSingletonIsTrueAndInstanceDescriptor_ShouldKeepDescriptorUnchanged()
-    {
-        // Arrange
-        var descriptor = ServiceDescriptor.Singleton<ICustomerService>(new CustomerService());
-        var source = new ServiceCollectionSource([descriptor]);
-
-        // Act
-        var result = source.AsScoped(ignoreSingletonImplementations: true);
-
-        // Assert
-        var single = Assert.Single(result);
-        Assert.Same(descriptor, single);
-        Assert.Equal(ServiceLifetime.Singleton, single.Lifetime);
     }
 
     [Fact]
@@ -104,43 +57,11 @@ public class ServiceSourceExtensionsTests
     }
 
     [Fact]
-    public void AsTransient_WhenIgnoreSingletonIsFalseAndInstanceDescriptor_ShouldThrow()
-    {
-        // Arrange
-        var source = new ServiceCollectionSource(
-        [
-            ServiceDescriptor.Singleton<ICustomerService>(new CustomerService()),
-        ]);
-
-        // Act
-        var act = () => source.AsTransient(ignoreSingletonImplementations: false);
-
-        // Assert
-        Assert.Throws<InvalidOperationException>(act);
-    }
-
-    [Fact]
-    public void AsTransient_WhenIgnoreSingletonIsTrueAndInstanceDescriptor_ShouldKeepDescriptorUnchanged()
-    {
-        // Arrange
-        var descriptor = ServiceDescriptor.Singleton<ICustomerService>(new CustomerService());
-        var source = new ServiceCollectionSource([descriptor]);
-
-        // Act
-        var result = source.AsTransient(ignoreSingletonImplementations: true);
-
-        // Assert
-        var single = Assert.Single(result);
-        Assert.Same(descriptor, single);
-        Assert.Equal(ServiceLifetime.Singleton, single.Lifetime);
-    }
-
-    [Fact]
     public void AsLifetime_WhenCalledWithLifetime_ShouldDefaultToIgnoreSingletonImplementations()
     {
         // Arrange
         var descriptor = ServiceDescriptor.Singleton<ICustomerService>(new CustomerService());
-        var source = new ServiceCollectionSource([descriptor]);
+        IServiceSource source = new ServiceCollectionSource([descriptor]);
 
         // Act
         var result = source.AsLifetime(ServiceLifetime.Scoped);
@@ -151,26 +72,10 @@ public class ServiceSourceExtensionsTests
     }
 
     [Fact]
-    public void AsLifetime_WhenIgnoreFalseAndInstanceDescriptor_ShouldThrow()
-    {
-        // Arrange
-        var source = new ServiceCollectionSource(
-        [
-            ServiceDescriptor.Singleton<ICustomerService>(new CustomerService()),
-        ]);
-
-        // Act
-        var act = () => source.AsLifetime(ServiceLifetime.Transient, ignoreSingletonImplementations: false);
-
-        // Assert
-        Assert.Throws<InvalidOperationException>(act);
-    }
-
-    [Fact]
     public void AsLifetime_WhenCalled_ShouldReturnNewServiceSource()
     {
         // Arrange
-        var source = new ServiceCollectionSource(
+        IServiceSource source = new ServiceCollectionSource(
         [
             ServiceDescriptor.Transient<ICustomerService, CustomerService>(),
         ]);
@@ -186,7 +91,7 @@ public class ServiceSourceExtensionsTests
     public void AsLifetime_WhenCalled_ShouldPreserveDescriptorCount()
     {
         // Arrange
-        var source = new ServiceCollectionSource(
+        IServiceSource source = new ServiceCollectionSource(
         [
             ServiceDescriptor.Transient<ICustomerService, CustomerService>(),
             ServiceDescriptor.Transient<ICustomerService, CustomerService>(),
@@ -203,7 +108,7 @@ public class ServiceSourceExtensionsTests
     public void AsLifetime_WhenCalled_ShouldPreserveServiceType()
     {
         // Arrange
-        var source = new ServiceCollectionSource(
+        IServiceSource source = new ServiceCollectionSource(
         [
             ServiceDescriptor.Transient<ICustomerService, CustomerService>(),
         ]);
@@ -217,4 +122,21 @@ public class ServiceSourceExtensionsTests
         Assert.Equal(typeof(CustomerService), single.ImplementationType);
     }
 
+    [Theory]
+    [InlineData(ServiceLifetime.Singleton)]
+    [InlineData(ServiceLifetime.Scoped)]
+    [InlineData(ServiceLifetime.Transient)]
+    public void AsLifetime_WhenDescriptorsAlreadyLifetime_ShouldReturnSameDescriptors(ServiceLifetime lifetime)
+    {
+        // Arrange
+        var descriptor = ServiceDescriptor.Describe(typeof(ICustomerService), typeof(CustomerService), lifetime);
+        var source = new ServiceCollectionSource([descriptor]);
+
+        // Act
+        var result = source.AsLifetime(lifetime);
+
+        // Assert
+        var single = Assert.Single(result);
+        Assert.Same(descriptor, single);
+    }
 }

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.UnitTests/ServiceSourceTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.UnitTests/ServiceSourceTests.cs
@@ -275,7 +275,7 @@ public class ServiceSourceTests
             this.serviceDescriptors = serviceDescriptors;
         }
 
-        protected override IEnumerable<ServiceDescriptor> SelectServices()
+        protected override IEnumerable<ServiceDescriptor> SelectServices(ServiceLifetime lifetime)
         {
             SelectServicesCallCount++;
             return this.serviceDescriptors;


### PR DESCRIPTION
Small optimization that allows services to have their lifetime set before the immutable service descriptors are allocated.

Closes #22