### PR TITLE
#37 - Rename Collect to ToServiceCollection

### DIFF
--- a/src/ZCrew.Extensions.DependencyInjection.Registration/IKeyedServiceSelector.IServiceSource.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/IKeyedServiceSelector.IServiceSource.cs
@@ -11,8 +11,8 @@ public partial interface IKeyedServiceSelector
     }
 
     /// <inheritdoc />
-    IServiceCollection IServiceSource.Collect()
+    IServiceCollection IServiceSource.ToServiceCollection(IServiceCollection serviceCollection)
     {
-        return Unkeyed().Collect();
+        return Unkeyed().ToServiceCollection(serviceCollection);
     }
 }

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/IServiceSource.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/IServiceSource.cs
@@ -5,7 +5,7 @@ namespace ZCrew.Extensions.DependencyInjection.Registration;
 /// <summary>
 ///     Represents a read-only service collection produced by the registration fluent API. This is the terminal type
 ///     in the registration chain, providing the resulting <see cref="ServiceDescriptor"/> registrations as an
-///     <see cref="IServiceCollection"/> via <see cref="Collect"/>.
+///     <see cref="IServiceCollection"/> via <see cref="ToServiceCollection"/>.
 /// </summary>
 public interface IServiceSource
 {
@@ -27,8 +27,8 @@ public interface IServiceSource
     IServiceCollection AsLifetime(ServiceLifetime lifetime, SharingMode sharingMode);
 
     /// <summary>
-    ///     Collects all the services into a <see cref="IServiceCollection"/>.
+    ///     Collects all the services into the <paramref name="serviceCollection"/>.
     /// </summary>
     /// <returns>The resulting service collection.</returns>
-    IServiceCollection Collect();
+    IServiceCollection ToServiceCollection(IServiceCollection serviceCollection);
 }

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceCollectionExtensions.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceCollectionExtensions.cs
@@ -21,7 +21,7 @@ public static class ServiceCollectionExtensions
         /// <param name="descriptors">The service descriptors to add.</param>
         public IServiceCollection AddSingleton(IServiceSource descriptors)
         {
-            return services.AddSingleton(descriptors.Collect());
+            return services.AddSingleton(descriptors.ToServiceCollection());
         }
 
         /// <summary>
@@ -30,7 +30,7 @@ public static class ServiceCollectionExtensions
         /// <param name="descriptors">The service descriptors to add.</param>
         public IServiceCollection AddSingleton(IKeyedServiceSelector descriptors)
         {
-            return services.AddSingleton(descriptors.Collect());
+            return services.AddSingleton(descriptors.ToServiceCollection());
         }
 
         /// <summary>
@@ -39,7 +39,7 @@ public static class ServiceCollectionExtensions
         /// <param name="descriptors">The service descriptors to add.</param>
         public IServiceCollection AddSingleton(IServiceSelector descriptors)
         {
-            return services.AddSingleton(descriptors.Collect());
+            return services.AddSingleton(descriptors.ToServiceCollection());
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ public static class ServiceCollectionExtensions
         /// <param name="descriptors">The service descriptors to add.</param>
         public IServiceCollection AddSingleton(ITypeFilter descriptors)
         {
-            return services.AddSingleton(descriptors.Collect());
+            return services.AddSingleton(descriptors.ToServiceCollection());
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ public static class ServiceCollectionExtensions
         /// <param name="descriptors">The service descriptors to add.</param>
         public IServiceCollection AddSingleton(ITypeSelector descriptors)
         {
-            return services.AddSingleton(descriptors.Collect());
+            return services.AddSingleton(descriptors.ToServiceCollection());
         }
 
         /// <summary>
@@ -66,7 +66,7 @@ public static class ServiceCollectionExtensions
         /// <param name="descriptors">The service descriptors to add.</param>
         public IServiceCollection AddSingleton(IAssemblyTypeSelector descriptors)
         {
-            return services.AddSingleton(descriptors.Collect());
+            return services.AddSingleton(descriptors.ToServiceCollection());
         }
     }
 }

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceSource.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceSource.cs
@@ -24,18 +24,21 @@ internal class ServiceSource : IServiceSource
             );
         }
 
-        return Collect(lifetime, sharingMode);
+        return ToServiceCollection(new ServiceCollection(), lifetime, sharingMode);
     }
 
     /// <inheritdoc />
-    public IServiceCollection Collect()
+    public IServiceCollection ToServiceCollection(IServiceCollection serviceCollection)
     {
-        return Collect(ServiceLifetime.Singleton, SharingMode.SharedComponent);
+        return ToServiceCollection(serviceCollection, ServiceLifetime.Singleton, SharingMode.SharedComponent);
     }
 
-    private IServiceCollection Collect(ServiceLifetime lifetime, SharingMode sharingMode)
+    private IServiceCollection ToServiceCollection(
+        IServiceCollection serviceCollection,
+        ServiceLifetime lifetime,
+        SharingMode sharingMode
+    )
     {
-        var serviceCollection = new ServiceCollection();
         foreach (var component in this.components)
         {
             var lifetimeComponent = component.WithLifetime(lifetime);

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceSourceExtensions.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceSourceExtensions.cs
@@ -10,6 +10,15 @@ public static class ServiceSourceExtensions
     extension(IServiceSource source)
     {
         /// <summary>
+        ///     Collects all the services into a <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <returns>The resulting service collection.</returns>
+        public IServiceCollection ToServiceCollection()
+        {
+            return source.ToServiceCollection(new ServiceCollection());
+        }
+
+        /// <summary>
         ///     Returns a new <see cref="IServiceSource"/> with all descriptors set to the specified
         ///     <paramref name="lifetime"/>. Instance-based descriptors that cannot change lifetime are kept unchanged.
         /// </summary>

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesAssemblyVisibilityTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesAssemblyVisibilityTests.cs
@@ -14,7 +14,7 @@ public class ClassesAssemblyVisibilityTests
         var assembly = typeof(CustomerService).Assembly;
 
         // Act
-        var result = Classes.FromAssembly(assembly).InNamespace(DomainServicesNamespace).AsSelf().Collect();
+        var result = Classes.FromAssembly(assembly).InNamespace(DomainServicesNamespace).AsSelf().ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -33,7 +33,7 @@ public class ClassesAssemblyVisibilityTests
             .IncludePublicTypes()
             .InNamespace(DomainServicesNamespace)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -52,7 +52,7 @@ public class ClassesAssemblyVisibilityTests
             .IncludeInternalTypes()
             .InNamespace(DomainServicesNamespace)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -71,7 +71,7 @@ public class ClassesAssemblyVisibilityTests
             .IncludeInternalTypes()
             .InNamespace(DomainServicesNamespace)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -91,7 +91,7 @@ public class ClassesAssemblyVisibilityTests
             .IncludeAllTypes()
             .InNamespace(DomainServicesNamespace)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesEndToEndTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesEndToEndTests.cs
@@ -6,6 +6,8 @@ using Fixtures.SmallProject.Domain.Services;
 using Fixtures.SmallProject.Infrastructure.External;
 using Fixtures.SmallProject.Infrastructure.Notifications;
 using Fixtures.SmallProject.Infrastructure.Persistence;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests.ClassesTests;
 
@@ -20,7 +22,7 @@ public class ClassesEndToEndTests
             .BasedOn(typeof(IRepository<>))
             .InNamespace("Fixtures.SmallProject.Infrastructure.Persistence", includeSubnamespaces: true)
             .AsInterface()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -41,7 +43,7 @@ public class ClassesEndToEndTests
             .FromAssemblyContaining<CustomerService>()
             .InNamespace("Fixtures.SmallProject.Application.Services")
             .AsDefaultNonSystemInterfaces()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -69,7 +71,7 @@ public class ClassesEndToEndTests
             .Where(t => !t.IsGenericTypeDefinition)
             .InNamespace("Fixtures.SmallProject.Domain.Services")
             .AsInterface()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -91,7 +93,7 @@ public class ClassesEndToEndTests
             .Where(t => !t.IsGenericTypeDefinition)
             .InNamespace("Fixtures.SmallProject.Infrastructure", includeSubnamespaces: true)
             .AsAllNonSystemInterfaces()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -103,5 +105,107 @@ public class ClassesEndToEndTests
             d => d.ImplementationType == typeof(EmailNotificationSender) && d.ServiceType == typeof(INotificationSender)
         );
         Assert.DoesNotContain(result, d => d.ServiceType == typeof(IDisposable));
+    }
+
+    [Fact]
+    public void ToServiceCollection_WhenGivenExistingCollection_ShouldAppendDescriptorsAndReturnSameInstance()
+    {
+        // Arrange
+        var existing = new ServiceCollection();
+        existing.Add(ServiceDescriptor.Singleton<IEventPublisher>(_ => null!));
+
+        // Act
+        var result = Classes
+            .FromAssemblyContaining<SqlCustomerRepository>()
+            .BasedOn(typeof(IRepository<>))
+            .InNamespace("Fixtures.SmallProject.Infrastructure.Persistence", includeSubnamespaces: true)
+            .AsInterface()
+            .Unkeyed()
+            .ToServiceCollection(existing);
+
+        // Assert
+        Assert.Same(existing, result);
+        Assert.Contains(result, d => d.ServiceType == typeof(IEventPublisher));
+        Assert.Contains(
+            result,
+            d => d.ImplementationType == typeof(SqlCustomerRepository) && d.ServiceType == typeof(ICustomerRepository)
+        );
+        Assert.Contains(
+            result,
+            d => d.ImplementationType == typeof(SqlOrderRepository) && d.ServiceType == typeof(IOrderRepository)
+        );
+    }
+
+    [Fact]
+    public void ToServiceCollection_WhenGivenExistingCollection_ShouldRegisterAddedDescriptorsAsSingleton()
+    {
+        // Arrange
+        var existing = new ServiceCollection();
+
+        // Act
+        var result = Classes
+            .FromAssemblyContaining<SqlCustomerRepository>()
+            .BasedOn(typeof(IRepository<>))
+            .InNamespace("Fixtures.SmallProject.Infrastructure.Persistence", includeSubnamespaces: true)
+            .AsInterface()
+            .Unkeyed()
+            .ToServiceCollection(existing);
+
+        // Assert
+        Assert.NotEmpty(result);
+        Assert.All(result, d => Assert.Equal(ServiceLifetime.Singleton, d.Lifetime));
+    }
+
+    [Fact]
+    public void ToServiceCollection_WhenCalledTwiceOnSameCollection_ShouldAppendBothBatches()
+    {
+        // Arrange
+        var existing = new ServiceCollection();
+
+        // Act
+        Classes
+            .FromAssemblyContaining<SqlCustomerRepository>()
+            .BasedOn(typeof(IRepository<>))
+            .InNamespace("Fixtures.SmallProject.Infrastructure.Persistence", includeSubnamespaces: true)
+            .AsInterface()
+            .Unkeyed()
+            .ToServiceCollection(existing);
+        Classes
+            .FromAssemblyContaining<CustomerService>()
+            .InNamespace("Fixtures.SmallProject.Application.Services")
+            .AsDefaultNonSystemInterfaces()
+            .Unkeyed()
+            .ToServiceCollection(existing);
+
+        // Assert
+        Assert.Contains(
+            existing,
+            d => d.ImplementationType == typeof(SqlCustomerRepository) && d.ServiceType == typeof(ICustomerRepository)
+        );
+        Assert.Contains(
+            existing,
+            d => d.ImplementationType == typeof(CustomerService) && d.ServiceType == typeof(ICustomerService)
+        );
+    }
+
+    [Fact]
+    public void ToServiceCollection_WhenCalledOnKeyedServiceSelector_ShouldAppendToExistingCollection()
+    {
+        // Arrange
+        var existing = new ServiceCollection();
+        existing.Add(ServiceDescriptor.Singleton<IEventPublisher>(_ => null!));
+
+        // Act
+        var result = Classes
+            .FromAssemblyContaining<SqlCustomerRepository>()
+            .BasedOn(typeof(IRepository<>))
+            .InNamespace("Fixtures.SmallProject.Infrastructure.Persistence", includeSubnamespaces: true)
+            .AsInterface()
+            .ToServiceCollection(existing);
+
+        // Assert
+        Assert.Same(existing, result);
+        Assert.Contains(result, d => d.ServiceType == typeof(IEventPublisher));
+        Assert.Contains(result, d => d.ImplementationType == typeof(SqlCustomerRepository));
     }
 }

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesEntryPointTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesEntryPointTests.cs
@@ -22,7 +22,7 @@ public class ClassesEntryPointTests
         ];
 
         // Act
-        var result = Classes.From(types).AsSelf().Collect();
+        var result = Classes.From(types).AsSelf().ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -47,7 +47,7 @@ public class ClassesEntryPointTests
                 typeof(OrderValidator)
             )
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -66,7 +66,7 @@ public class ClassesEntryPointTests
         var assembly = typeof(CustomerService).Assembly;
 
         // Act
-        var result = Classes.FromAssembly(assembly).AsSelf().Collect();
+        var result = Classes.FromAssembly(assembly).AsSelf().ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -80,7 +80,7 @@ public class ClassesEntryPointTests
     public void FromAssemblyContaining_WithType_ShouldScanCorrectAssembly()
     {
         // Act
-        var result = Classes.FromAssemblyContaining(typeof(CustomerService)).AsSelf().Collect();
+        var result = Classes.FromAssemblyContaining(typeof(CustomerService)).AsSelf().ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -93,7 +93,7 @@ public class ClassesEntryPointTests
     public void FromAssemblyContaining_WithGeneric_ShouldScanCorrectAssembly()
     {
         // Act
-        var result = Classes.FromAssemblyContaining<CustomerService>().AsSelf().Collect();
+        var result = Classes.FromAssemblyContaining<CustomerService>().AsSelf().ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -146,7 +146,7 @@ public class ClassesEntryPointTests
     public void From_WhenCalled_ShouldDefaultToSingletonLifetime()
     {
         // Act
-        var result = Classes.From(typeof(CustomerService)).AsSelf().Collect();
+        var result = Classes.From(typeof(CustomerService)).AsSelf().ToServiceCollection();
 
         // Assert
         Assert.All(result, descriptor => Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime));
@@ -159,7 +159,7 @@ public class ClassesEntryPointTests
         var selector = Classes.From(typeof(CustomerService));
 
         // Act
-        var result = selector.Collect();
+        var result = selector.ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -172,7 +172,7 @@ public class ClassesEntryPointTests
     public void FromThisAssembly_WhenCalled_ShouldScanCallingAssembly()
     {
         // Act
-        var result = Classes.FromThisAssembly().Where(t => t == typeof(ClassesEntryPointTests)).AsSelf().Collect();
+        var result = Classes.FromThisAssembly().Where(t => t == typeof(ClassesEntryPointTests)).AsSelf().ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesKeyedServiceTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesKeyedServiceTests.cs
@@ -14,7 +14,7 @@ public class ClassesKeyedServiceTests
             .From(typeof(PayPalPaymentGateway), typeof(StripePaymentGateway))
             .AsInterface<IPaymentGateway>()
             .Keyed()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -41,7 +41,7 @@ public class ClassesKeyedServiceTests
             .From(typeof(PayPalPaymentGateway), typeof(StripePaymentGateway))
             .AsInterface<IPaymentGateway>()
             .Keyed("myKey")
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.All(result, d => Assert.Equal("myKey", d.ServiceKey));
@@ -56,7 +56,7 @@ public class ClassesKeyedServiceTests
             .From(typeof(PayPalPaymentGateway), typeof(StripePaymentGateway))
             .AsInterface<IPaymentGateway>()
             .Keyed((object?)null)
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.All(result, d => Assert.False(d.IsKeyedService));
@@ -70,7 +70,7 @@ public class ClassesKeyedServiceTests
             .From(typeof(PayPalPaymentGateway), typeof(StripePaymentGateway))
             .AsInterface<IPaymentGateway>()
             .Keyed(type => type.Name)
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -97,7 +97,7 @@ public class ClassesKeyedServiceTests
             .From(typeof(EmailNotificationSender), typeof(SmsNotificationSender))
             .AsInterface<INotificationSender>()
             .Keyed((impl, svc) => $"{impl.Name}:{svc.Name}")
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -118,7 +118,7 @@ public class ClassesKeyedServiceTests
             .From(typeof(PayPalPaymentGateway), typeof(StripePaymentGateway))
             .AsInterface<IPaymentGateway>()
             .Keyed(type => type == typeof(PayPalPaymentGateway) ? "PayPal" : null)
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -138,7 +138,7 @@ public class ClassesKeyedServiceTests
         // and stripping would yield empty string
 
         // Act
-        var result = Classes.From(typeof(PayPalPaymentGateway)).AsSelf().Keyed().Collect();
+        var result = Classes.From(typeof(PayPalPaymentGateway)).AsSelf().Keyed().ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesNameEndsWithTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesNameEndsWithTests.cs
@@ -10,7 +10,7 @@ public class ClassesNameEndsWithTests
     public void NameEndsWith_WithSuffix_ShouldFilterToMatchingTypes()
     {
         // Act
-        var result = Classes.FromAssemblyContaining<CustomerService>().NameEndsWith("Service").AsSelf().Collect();
+        var result = Classes.FromAssemblyContaining<CustomerService>().NameEndsWith("Service").AsSelf().ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -25,7 +25,7 @@ public class ClassesNameEndsWithTests
     public void NameEndsWith_WithNoMatches_ShouldReturnEmpty()
     {
         // Act
-        var result = Classes.FromAssemblyContaining<CustomerService>().NameEndsWith("Nonexistent").AsSelf().Collect();
+        var result = Classes.FromAssemblyContaining<CustomerService>().NameEndsWith("Nonexistent").AsSelf().ToServiceCollection();
 
         // Assert
         Assert.Empty(result);
@@ -35,7 +35,7 @@ public class ClassesNameEndsWithTests
     public void NameEndsWith_WithWrongCase_ShouldNotMatch()
     {
         // Act
-        var result = Classes.FromAssemblyContaining<CustomerService>().NameEndsWith("service").AsSelf().Collect();
+        var result = Classes.FromAssemblyContaining<CustomerService>().NameEndsWith("service").AsSelf().ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -50,7 +50,7 @@ public class ClassesNameEndsWithTests
             .FromAssemblyContaining<CustomerService>()
             .NameEndsWith("service", ignoreCase: true)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -67,7 +67,7 @@ public class ClassesNameEndsWithTests
             .FromAssemblyContaining<CustomerService>()
             .NameEndsWith("service", ignoreCase: false)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -82,7 +82,7 @@ public class ClassesNameEndsWithTests
             .FromAssemblyContaining<CustomerService>()
             .NameEndsWith("gateway", StringComparison.OrdinalIgnoreCase)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -95,7 +95,7 @@ public class ClassesNameEndsWithTests
     public void NameEndsWith_WithGenericTypes_ShouldStripArityBeforeMatching()
     {
         // Act
-        var result = Classes.FromAssemblyContaining<CustomerService>().NameEndsWith("Repository").AsSelf().Collect();
+        var result = Classes.FromAssemblyContaining<CustomerService>().NameEndsWith("Repository").AsSelf().ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -113,7 +113,7 @@ public class ClassesNameEndsWithTests
             .Where(t => !t.Name.StartsWith("Sql"))
             .NameEndsWith("Repository")
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesNamespaceFilterTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesNamespaceFilterTests.cs
@@ -15,7 +15,7 @@ public class ClassesNamespaceFilterTests
             .FromAssemblyContaining<CustomerService>()
             .InNamespace("Fixtures.SmallProject.Application.Services")
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -34,7 +34,7 @@ public class ClassesNamespaceFilterTests
             .FromAssemblyContaining<CustomerService>()
             .InNamespace("Fixtures.SmallProject.Infrastructure", includeSubnamespaces: true)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -52,7 +52,7 @@ public class ClassesNamespaceFilterTests
             .FromAssemblyContaining<CustomerService>()
             .InNamespace("Fixtures.SmallProject.Infrastructure")
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Empty(result);
@@ -66,7 +66,7 @@ public class ClassesNamespaceFilterTests
             .FromAssemblyContaining<CustomerService>()
             .InSameNamespaceAs(typeof(CustomerService))
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -83,7 +83,7 @@ public class ClassesNamespaceFilterTests
             .FromAssemblyContaining<CustomerService>()
             .InSameNamespaceAs<CustomerService>()
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -100,7 +100,7 @@ public class ClassesNamespaceFilterTests
             .FromAssemblyContaining<CustomerService>()
             .InSameNamespaceAs<CustomerService>(includeSubnamespaces: true)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -116,7 +116,7 @@ public class ClassesNamespaceFilterTests
             .FromAssemblyContaining<CustomerService>()
             .InSameNamespaceAs(typeof(PayPalPaymentGateway), includeSubnamespaces: true)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -134,7 +134,7 @@ public class ClassesNamespaceFilterTests
             .Where(t => !t.Name.StartsWith("Stripe"))
             .InSameNamespaceAs<PayPalPaymentGateway>(includeSubnamespaces: true)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesServiceSelectionTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesServiceSelectionTests.cs
@@ -15,7 +15,7 @@ public class ClassesServiceSelectionTests
     public void AsSelf_WhenCalled_ShouldRegisterAsImplementationType()
     {
         // Act
-        var result = Classes.From(typeof(CustomerService)).AsSelf().Collect();
+        var result = Classes.From(typeof(CustomerService)).AsSelf().ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -27,7 +27,7 @@ public class ClassesServiceSelectionTests
     public void AsAllInterfaces_WhenCalled_ShouldRegisterAllInterfaces()
     {
         // Act
-        var result = Classes.From(typeof(PayPalPaymentGateway)).AsAllInterfaces().Collect();
+        var result = Classes.From(typeof(PayPalPaymentGateway)).AsAllInterfaces().ToServiceCollection();
 
         // Assert
         var serviceTypes = result.Select(d => d.ServiceType).ToArray();
@@ -39,7 +39,7 @@ public class ClassesServiceSelectionTests
     public void AsAllNonSystemInterfaces_WhenCalled_ShouldExcludeSystemInterfaces()
     {
         // Act
-        var result = Classes.From(typeof(PayPalPaymentGateway)).AsAllNonSystemInterfaces().Collect();
+        var result = Classes.From(typeof(PayPalPaymentGateway)).AsAllNonSystemInterfaces().ToServiceCollection();
 
         // Assert
         var serviceTypes = result.Select(d => d.ServiceType).ToArray();
@@ -54,7 +54,7 @@ public class ClassesServiceSelectionTests
         var result = Classes
             .From(typeof(CustomerService), typeof(EmailNotificationSender))
             .AsDefaultInterfaces()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -71,7 +71,7 @@ public class ClassesServiceSelectionTests
     public void AsDefaultInterfaces_WhenNoConventionMatch_ShouldNotRegister()
     {
         // Act
-        var result = Classes.From(typeof(Customer)).AsDefaultInterfaces().Collect();
+        var result = Classes.From(typeof(Customer)).AsDefaultInterfaces().ToServiceCollection();
 
         // Assert
         Assert.Empty(result);
@@ -81,7 +81,7 @@ public class ClassesServiceSelectionTests
     public void AsDefaultNonSystemInterfaces_WhenCalled_ShouldCombineBothFilters()
     {
         // Act
-        var result = Classes.From(typeof(PayPalPaymentGateway)).AsDefaultNonSystemInterfaces().Collect();
+        var result = Classes.From(typeof(PayPalPaymentGateway)).AsDefaultNonSystemInterfaces().ToServiceCollection();
 
         // Assert
         var serviceTypes = result.Select(d => d.ServiceType).ToArray();
@@ -93,7 +93,7 @@ public class ClassesServiceSelectionTests
     public void AsFirstInterface_WhenCalled_ShouldRegisterFirstInterface()
     {
         // Act
-        var result = Classes.From(typeof(CustomerService)).AsFirstInterface().Collect();
+        var result = Classes.From(typeof(CustomerService)).AsFirstInterface().ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -105,7 +105,7 @@ public class ClassesServiceSelectionTests
     public void AsFirstInterface_WhenNoInterfaces_ShouldNotRegister()
     {
         // Act
-        var result = Classes.From(typeof(Customer)).AsFirstInterface().Collect();
+        var result = Classes.From(typeof(Customer)).AsFirstInterface().ToServiceCollection();
 
         // Assert
         Assert.Empty(result);
@@ -115,7 +115,7 @@ public class ClassesServiceSelectionTests
     public void AsInterface_WithBasedOn_ShouldRegisterTopLevelDerivedInterfaces()
     {
         // Act
-        var result = Classes.From(typeof(SqlCustomerRepository)).BasedOn(typeof(IRepository<>)).AsInterface().Collect();
+        var result = Classes.From(typeof(SqlCustomerRepository)).BasedOn(typeof(IRepository<>)).AsInterface().ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -127,7 +127,7 @@ public class ClassesServiceSelectionTests
     public void AsInterface_WithGenericTypeArg_ShouldRegisterDerivedInterfaces()
     {
         // Act
-        var result = Classes.From(typeof(PayPalPaymentGateway)).AsInterface<IPaymentGateway>().Collect();
+        var result = Classes.From(typeof(PayPalPaymentGateway)).AsInterface<IPaymentGateway>().ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -139,7 +139,7 @@ public class ClassesServiceSelectionTests
     public void AsInterface_WithExplicitType_ShouldRegisterDerivedInterfaces()
     {
         // Act
-        var result = Classes.From(typeof(PayPalPaymentGateway)).AsInterface(typeof(IPaymentGateway)).Collect();
+        var result = Classes.From(typeof(PayPalPaymentGateway)).AsInterface(typeof(IPaymentGateway)).ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -151,7 +151,7 @@ public class ClassesServiceSelectionTests
     public void AsBase_WithBasedOn_ShouldRegisterAsBaseTypes()
     {
         // Act
-        var result = Classes.From(typeof(CustomerService)).BasedOn<ICustomerService>().AsBase().Collect();
+        var result = Classes.From(typeof(CustomerService)).BasedOn<ICustomerService>().AsBase().ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -163,7 +163,7 @@ public class ClassesServiceSelectionTests
     public void As_WithCustomSelector_ShouldUseProvidedFunction()
     {
         // Act
-        var result = Classes.From(typeof(CustomerService)).As(type => type.GetInterfaces()).Collect();
+        var result = Classes.From(typeof(CustomerService)).As(type => type.GetInterfaces()).ToServiceCollection();
 
         // Assert
         var serviceTypes = result.Select(d => d.ServiceType).ToArray();
@@ -179,7 +179,7 @@ public class ClassesServiceSelectionTests
             .From(typeof(CustomerService))
             .BasedOn<ICustomerService>()
             .As((_, bases) => bases)
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -194,7 +194,7 @@ public class ClassesServiceSelectionTests
         var result = Classes
             .From(typeof(CustomerService), typeof(OrderService))
             .AsInterfaces(typeof(ICustomerService), typeof(IOrderService))
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -214,7 +214,7 @@ public class ClassesServiceSelectionTests
         var result = Classes
             .From(typeof(SqlCustomerRepository), typeof(SqlOrderRepository))
             .AsInterfaces(typeof(IRepository<>))
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -231,7 +231,7 @@ public class ClassesServiceSelectionTests
     public void AsInterface_WithOpenGenericTypeArg_ShouldRegisterTopLevelDerivedInterfaces()
     {
         // Act
-        var result = Classes.From(typeof(SqlCustomerRepository)).AsInterface(typeof(IRepository<>)).Collect();
+        var result = Classes.From(typeof(SqlCustomerRepository)).AsInterface(typeof(IRepository<>)).ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -247,7 +247,7 @@ public class ClassesServiceSelectionTests
             .From(typeof(SqlCustomerRepository))
             .BasedOn(typeof(RepositoryBase<>))
             .AsBase()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -259,7 +259,7 @@ public class ClassesServiceSelectionTests
     public void AsInterface_T_WhenTypeHasNoMatchingInterface_ShouldNotRegister()
     {
         // Act
-        var result = Classes.From(typeof(CustomerService)).AsInterface<IPaymentGateway>().Collect();
+        var result = Classes.From(typeof(CustomerService)).AsInterface<IPaymentGateway>().ToServiceCollection();
 
         // Assert
         Assert.Empty(result);
@@ -273,7 +273,7 @@ public class ClassesServiceSelectionTests
             .From(typeof(LoggingStep<>))
             .BasedOn(typeof(Pipeline<>.IStep))
             .AsBase()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -289,7 +289,7 @@ public class ClassesServiceSelectionTests
             .From(typeof(OrderValidationStep))
             .BasedOn(typeof(Pipeline<>.IStep))
             .AsBase()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -305,7 +305,7 @@ public class ClassesServiceSelectionTests
             .From(typeof(LoggingStep<>))
             .BasedOn(typeof(Pipeline<>.IStep))
             .AsInterface()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -321,7 +321,7 @@ public class ClassesServiceSelectionTests
             .From(typeof(OrderValidationStep))
             .BasedOn(typeof(Pipeline<>.IStep))
             .AsInterface()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesWhereFilterTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesWhereFilterTests.cs
@@ -16,7 +16,7 @@ public class ClassesWhereFilterTests
             .From(typeof(CustomerService), typeof(OrderService), typeof(OrderValidator), typeof(PayPalPaymentGateway))
             .Where(t => t.Name.EndsWith("Service"))
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -35,7 +35,7 @@ public class ClassesWhereFilterTests
             .Where(t => t.Name.EndsWith("Service"))
             .Where(t => t.Name.StartsWith("Customer"))
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -51,7 +51,7 @@ public class ClassesWhereFilterTests
             .From(typeof(CustomerService), typeof(CachingCustomerService), typeof(OrderService), typeof(ProductService))
             .BasedOn<ICustomerService>()
             .AsBase()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var descriptors = result.ToArray();
@@ -75,7 +75,7 @@ public class ClassesWhereFilterTests
             )
             .BasedOn(typeof(IValidator<>))
             .AsBase()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var descriptors = result.ToArray();
@@ -98,7 +98,7 @@ public class ClassesWhereFilterTests
             .From(typeof(CustomerService), typeof(OrderService), typeof(ProductService), typeof(PayPalPaymentGateway))
             .BasedOn(typeof(ICustomerService), typeof(IOrderService))
             .AsBase()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var implementationTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -117,7 +117,7 @@ public class ClassesWhereFilterTests
             .Where(t => !t.Name.StartsWith("Caching"))
             .BasedOn<ICustomerService>()
             .AsBase()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var descriptors = result.ToArray();
@@ -134,7 +134,7 @@ public class ClassesWhereFilterTests
             .From(typeof(CustomerService), typeof(OrderService), typeof(ProductService))
             .AllTypes()
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -153,7 +153,7 @@ public class ClassesWhereFilterTests
             .BasedOn<ICustomerService>()
             .BasedOn<IOrderService>()
             .AsBase()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var implementationTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -171,7 +171,7 @@ public class ClassesWhereFilterTests
             .BasedOn<ICustomerService>()
             .BasedOn(typeof(IValidator<>))
             .AsBase()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -192,7 +192,7 @@ public class ClassesWhereFilterTests
         var filter = Classes.From(typeof(CustomerService), typeof(OrderService)).BasedOn<ICustomerService>();
 
         // Act
-        var result = filter.Collect();
+        var result = filter.ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -210,7 +210,7 @@ public class ClassesWhereFilterTests
             .BasedOn(typeof(IValidator<>));
 
         // Act
-        var result = filter.Collect();
+        var result = filter.ToServiceCollection();
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -242,7 +242,7 @@ public class ClassesWhereFilterTests
         var filter = Classes.FromAssemblyContaining<CustomerService>().Where(t => t == typeof(CustomerService));
 
         // Act
-        var result = filter.Collect();
+        var result = filter.ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesAssemblyVisibilityTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesAssemblyVisibilityTests.cs
@@ -14,7 +14,7 @@ public class TypesAssemblyVisibilityTests
         var assembly = typeof(CustomerService).Assembly;
 
         // Act
-        var result = Types.FromAssembly(assembly).InNamespace(DomainServicesNamespace).AsSelf().Collect();
+        var result = Types.FromAssembly(assembly).InNamespace(DomainServicesNamespace).AsSelf().ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -28,7 +28,7 @@ public class TypesAssemblyVisibilityTests
         var assembly = typeof(CustomerService).Assembly;
 
         // Act
-        var result = Types.FromAssembly(assembly).InNamespace(DomainServicesNamespace).AsSelf().Collect();
+        var result = Types.FromAssembly(assembly).InNamespace(DomainServicesNamespace).AsSelf().ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -49,7 +49,7 @@ public class TypesAssemblyVisibilityTests
             .IncludePublicTypes()
             .InNamespace(DomainServicesNamespace)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -68,7 +68,7 @@ public class TypesAssemblyVisibilityTests
             .IncludeInternalTypes()
             .InNamespace(DomainServicesNamespace)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -87,7 +87,7 @@ public class TypesAssemblyVisibilityTests
             .IncludeInternalTypes()
             .InNamespace(DomainServicesNamespace)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -107,7 +107,7 @@ public class TypesAssemblyVisibilityTests
             .IncludeAllTypes()
             .InNamespace(DomainServicesNamespace)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesEndToEndTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesEndToEndTests.cs
@@ -6,6 +6,7 @@ using Fixtures.SmallProject.Domain.Services;
 using Fixtures.SmallProject.Infrastructure.External;
 using Fixtures.SmallProject.Infrastructure.Notifications;
 using Fixtures.SmallProject.Infrastructure.Persistence;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests.TypesTests;
 
@@ -20,7 +21,7 @@ public class TypesEndToEndTests
             .BasedOn(typeof(IRepository<>))
             .InNamespace("Fixtures.SmallProject.Infrastructure.Persistence", includeSubnamespaces: true)
             .AsInterface()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -41,7 +42,7 @@ public class TypesEndToEndTests
             .FromAssemblyContaining<CustomerService>()
             .InNamespace("Fixtures.SmallProject.Application.Services")
             .AsDefaultNonSystemInterfaces()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -69,7 +70,7 @@ public class TypesEndToEndTests
             .Where(t => !t.IsGenericTypeDefinition)
             .InNamespace("Fixtures.SmallProject.Domain.Services")
             .AsInterface()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -91,7 +92,7 @@ public class TypesEndToEndTests
             .Where(t => !t.IsGenericTypeDefinition)
             .InNamespace("Fixtures.SmallProject.Infrastructure", includeSubnamespaces: true)
             .AsAllNonSystemInterfaces()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -114,7 +115,7 @@ public class TypesEndToEndTests
             .Where(t => t.IsInterface)
             .InNamespace("Fixtures.SmallProject.Application.Services")
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -132,7 +133,7 @@ public class TypesEndToEndTests
             .FromAssemblyContaining<OrderValidator>()
             .InNamespace("Fixtures.SmallProject.Domain.Services")
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -141,5 +142,107 @@ public class TypesEndToEndTests
         Assert.Contains(typeof(PricingDefaults), registeredTypes);
         Assert.Contains(typeof(OrderValidator), registeredTypes);
         Assert.Contains(typeof(CustomerValidator), registeredTypes);
+    }
+
+    [Fact]
+    public void ToServiceCollection_WhenGivenExistingCollection_ShouldAppendDescriptorsAndReturnSameInstance()
+    {
+        // Arrange
+        var existing = new ServiceCollection();
+        existing.AddSingleton<IEventPublisher>(_ => null!);
+
+        // Act
+        var result = Types
+            .FromAssemblyContaining<SqlCustomerRepository>()
+            .BasedOn(typeof(IRepository<>))
+            .InNamespace("Fixtures.SmallProject.Infrastructure.Persistence", includeSubnamespaces: true)
+            .AsInterface()
+            .Unkeyed()
+            .ToServiceCollection(existing);
+
+        // Assert
+        Assert.Same(existing, result);
+        Assert.Contains(result, d => d.ServiceType == typeof(IEventPublisher));
+        Assert.Contains(
+            result,
+            d => d.ImplementationType == typeof(SqlCustomerRepository) && d.ServiceType == typeof(ICustomerRepository)
+        );
+        Assert.Contains(
+            result,
+            d => d.ImplementationType == typeof(SqlOrderRepository) && d.ServiceType == typeof(IOrderRepository)
+        );
+    }
+
+    [Fact]
+    public void ToServiceCollection_WhenGivenExistingCollection_ShouldRegisterAddedDescriptorsAsSingleton()
+    {
+        // Arrange
+        var existing = new ServiceCollection();
+
+        // Act
+        var result = Types
+            .FromAssemblyContaining<SqlCustomerRepository>()
+            .BasedOn(typeof(IRepository<>))
+            .InNamespace("Fixtures.SmallProject.Infrastructure.Persistence", includeSubnamespaces: true)
+            .AsInterface()
+            .Unkeyed()
+            .ToServiceCollection(existing);
+
+        // Assert
+        Assert.NotEmpty(result);
+        Assert.All(result, d => Assert.Equal(ServiceLifetime.Singleton, d.Lifetime));
+    }
+
+    [Fact]
+    public void ToServiceCollection_WhenCalledTwiceOnSameCollection_ShouldAppendBothBatches()
+    {
+        // Arrange
+        var existing = new ServiceCollection();
+
+        // Act
+        Types
+            .FromAssemblyContaining<SqlCustomerRepository>()
+            .BasedOn(typeof(IRepository<>))
+            .InNamespace("Fixtures.SmallProject.Infrastructure.Persistence", includeSubnamespaces: true)
+            .AsInterface()
+            .Unkeyed()
+            .ToServiceCollection(existing);
+        Types
+            .FromAssemblyContaining<CustomerService>()
+            .InNamespace("Fixtures.SmallProject.Application.Services")
+            .AsDefaultNonSystemInterfaces()
+            .Unkeyed()
+            .ToServiceCollection(existing);
+
+        // Assert
+        Assert.Contains(
+            existing,
+            d => d.ImplementationType == typeof(SqlCustomerRepository) && d.ServiceType == typeof(ICustomerRepository)
+        );
+        Assert.Contains(
+            existing,
+            d => d.ImplementationType == typeof(CustomerService) && d.ServiceType == typeof(ICustomerService)
+        );
+    }
+
+    [Fact]
+    public void ToServiceCollection_WhenCalledOnKeyedServiceSelector_ShouldAppendToExistingCollection()
+    {
+        // Arrange
+        var existing = new ServiceCollection();
+        existing.AddSingleton<IEventPublisher>(_ => null!);
+
+        // Act
+        var result = Types
+            .FromAssemblyContaining<SqlCustomerRepository>()
+            .BasedOn(typeof(IRepository<>))
+            .InNamespace("Fixtures.SmallProject.Infrastructure.Persistence", includeSubnamespaces: true)
+            .AsInterface()
+            .ToServiceCollection(existing);
+
+        // Assert
+        Assert.Same(existing, result);
+        Assert.Contains(result, d => d.ServiceType == typeof(IEventPublisher));
+        Assert.Contains(result, d => d.ImplementationType == typeof(SqlCustomerRepository));
     }
 }

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesEntryPointTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesEntryPointTests.cs
@@ -22,7 +22,7 @@ public class TypesEntryPointTests
         ];
 
         // Act
-        var result = Types.From(types).AsSelf().Collect();
+        var result = Types.From(types).AsSelf().ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -47,7 +47,7 @@ public class TypesEntryPointTests
                 typeof(OrderValidator)
             )
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -63,7 +63,7 @@ public class TypesEntryPointTests
     public void From_WithInterfaces_ShouldIncludeInterfaces()
     {
         // Act
-        var result = Types.From(typeof(ICustomerService), typeof(CustomerService)).AsSelf().Collect();
+        var result = Types.From(typeof(ICustomerService), typeof(CustomerService)).AsSelf().ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -75,7 +75,7 @@ public class TypesEntryPointTests
     public void From_WithAbstractClasses_ShouldIncludeAbstractClasses()
     {
         // Act
-        var result = Types.From(typeof(RepositoryBase<Customer>), typeof(SqlCustomerRepository)).AsSelf().Collect();
+        var result = Types.From(typeof(RepositoryBase<Customer>), typeof(SqlCustomerRepository)).AsSelf().ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -87,7 +87,7 @@ public class TypesEntryPointTests
     public void From_WithStaticClasses_ShouldIncludeStaticClasses()
     {
         // Act
-        var result = Types.From(typeof(PricingDefaults), typeof(CustomerService)).AsSelf().Collect();
+        var result = Types.From(typeof(PricingDefaults), typeof(CustomerService)).AsSelf().ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -99,7 +99,7 @@ public class TypesEntryPointTests
     public void From_WithStructs_ShouldIncludeStructs()
     {
         // Act
-        var result = Types.From(typeof(Currency), typeof(CustomerService)).AsSelf().Collect();
+        var result = Types.From(typeof(Currency), typeof(CustomerService)).AsSelf().ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -111,7 +111,7 @@ public class TypesEntryPointTests
     public void From_WithEnums_ShouldIncludeEnums()
     {
         // Act
-        var result = Types.From(typeof(OrderStatus), typeof(CustomerService)).AsSelf().Collect();
+        var result = Types.From(typeof(OrderStatus), typeof(CustomerService)).AsSelf().ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -126,7 +126,7 @@ public class TypesEntryPointTests
         var assembly = typeof(CustomerService).Assembly;
 
         // Act
-        var result = Types.FromAssembly(assembly).AsSelf().Collect();
+        var result = Types.FromAssembly(assembly).AsSelf().ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -140,7 +140,7 @@ public class TypesEntryPointTests
     public void FromAssemblyContaining_WithType_ShouldScanCorrectAssembly()
     {
         // Act
-        var result = Types.FromAssemblyContaining(typeof(CustomerService)).AsSelf().Collect();
+        var result = Types.FromAssemblyContaining(typeof(CustomerService)).AsSelf().ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -154,7 +154,7 @@ public class TypesEntryPointTests
     public void FromAssemblyContaining_WithGeneric_ShouldScanCorrectAssembly()
     {
         // Act
-        var result = Types.FromAssemblyContaining<CustomerService>().AsSelf().Collect();
+        var result = Types.FromAssemblyContaining<CustomerService>().AsSelf().ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -208,7 +208,7 @@ public class TypesEntryPointTests
     public void From_WhenCalled_ShouldDefaultToSingletonLifetime()
     {
         // Act
-        var result = Types.From(typeof(CustomerService)).AsSelf().Collect();
+        var result = Types.From(typeof(CustomerService)).AsSelf().ToServiceCollection();
 
         // Assert
         Assert.All(result, descriptor => Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime));
@@ -221,7 +221,7 @@ public class TypesEntryPointTests
         var selector = Types.From(typeof(CustomerService));
 
         // Act
-        var result = selector.Collect();
+        var result = selector.ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -234,7 +234,7 @@ public class TypesEntryPointTests
     public void FromThisAssembly_WhenCalled_ShouldScanCallingAssembly()
     {
         // Act
-        var result = Types.FromThisAssembly().Where(t => t == typeof(TypesEntryPointTests)).AsSelf().Collect();
+        var result = Types.FromThisAssembly().Where(t => t == typeof(TypesEntryPointTests)).AsSelf().ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesKeyedServiceTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesKeyedServiceTests.cs
@@ -14,7 +14,7 @@ public class TypesKeyedServiceTests
             .From(typeof(PayPalPaymentGateway), typeof(StripePaymentGateway))
             .AsInterface<IPaymentGateway>()
             .Keyed()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -41,7 +41,7 @@ public class TypesKeyedServiceTests
             .From(typeof(PayPalPaymentGateway), typeof(StripePaymentGateway))
             .AsInterface<IPaymentGateway>()
             .Keyed("myKey")
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.All(result, d => Assert.Equal("myKey", d.ServiceKey));
@@ -56,7 +56,7 @@ public class TypesKeyedServiceTests
             .From(typeof(PayPalPaymentGateway), typeof(StripePaymentGateway))
             .AsInterface<IPaymentGateway>()
             .Keyed((object?)null)
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.All(result, d => Assert.False(d.IsKeyedService));
@@ -70,7 +70,7 @@ public class TypesKeyedServiceTests
             .From(typeof(PayPalPaymentGateway), typeof(StripePaymentGateway))
             .AsInterface<IPaymentGateway>()
             .Keyed(type => type.Name)
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -97,7 +97,7 @@ public class TypesKeyedServiceTests
             .From(typeof(EmailNotificationSender), typeof(SmsNotificationSender))
             .AsInterface<INotificationSender>()
             .Keyed((impl, svc) => $"{impl.Name}:{svc.Name}")
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -118,7 +118,7 @@ public class TypesKeyedServiceTests
             .From(typeof(PayPalPaymentGateway), typeof(StripePaymentGateway))
             .AsInterface<IPaymentGateway>()
             .Keyed(type => type == typeof(PayPalPaymentGateway) ? "PayPal" : null)
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -135,7 +135,7 @@ public class TypesKeyedServiceTests
     public void Keyed_WhenAutoDetectYieldsEmpty_ShouldSkipKeying()
     {
         // Act
-        var result = Types.From(typeof(PayPalPaymentGateway)).AsSelf().Keyed().Collect();
+        var result = Types.From(typeof(PayPalPaymentGateway)).AsSelf().Keyed().ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesNameEndsWithTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesNameEndsWithTests.cs
@@ -12,7 +12,7 @@ public class TypesNameEndsWithTests
     public void NameEndsWith_WithSuffix_ShouldFilterToMatchingTypes()
     {
         // Act
-        var result = Types.FromAssemblyContaining<CustomerService>().NameEndsWith("Service").AsSelf().Collect();
+        var result = Types.FromAssemblyContaining<CustomerService>().NameEndsWith("Service").AsSelf().ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -30,7 +30,7 @@ public class TypesNameEndsWithTests
     public void NameEndsWith_WithNoMatches_ShouldReturnEmpty()
     {
         // Act
-        var result = Types.FromAssemblyContaining<CustomerService>().NameEndsWith("Nonexistent").AsSelf().Collect();
+        var result = Types.FromAssemblyContaining<CustomerService>().NameEndsWith("Nonexistent").AsSelf().ToServiceCollection();
 
         // Assert
         Assert.Empty(result);
@@ -40,7 +40,7 @@ public class TypesNameEndsWithTests
     public void NameEndsWith_WithWrongCase_ShouldNotMatch()
     {
         // Act
-        var result = Types.FromAssemblyContaining<CustomerService>().NameEndsWith("service").AsSelf().Collect();
+        var result = Types.FromAssemblyContaining<CustomerService>().NameEndsWith("service").AsSelf().ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -55,7 +55,7 @@ public class TypesNameEndsWithTests
             .FromAssemblyContaining<CustomerService>()
             .NameEndsWith("service", ignoreCase: true)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -73,7 +73,7 @@ public class TypesNameEndsWithTests
             .FromAssemblyContaining<CustomerService>()
             .NameEndsWith("service", ignoreCase: false)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -88,7 +88,7 @@ public class TypesNameEndsWithTests
             .FromAssemblyContaining<CustomerService>()
             .NameEndsWith("gateway", StringComparison.OrdinalIgnoreCase)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -102,7 +102,7 @@ public class TypesNameEndsWithTests
     public void NameEndsWith_WithGenericTypes_ShouldStripArityBeforeMatching()
     {
         // Act
-        var result = Types.FromAssemblyContaining<CustomerService>().NameEndsWith("Repository").AsSelf().Collect();
+        var result = Types.FromAssemblyContaining<CustomerService>().NameEndsWith("Repository").AsSelf().ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -121,7 +121,7 @@ public class TypesNameEndsWithTests
             .Where(t => !t.Name.StartsWith("Sql"))
             .NameEndsWith("Repository")
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesNamespaceFilterTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesNamespaceFilterTests.cs
@@ -15,7 +15,7 @@ public class TypesNamespaceFilterTests
             .FromAssemblyContaining<CustomerService>()
             .InNamespace("Fixtures.SmallProject.Application.Services")
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -37,7 +37,7 @@ public class TypesNamespaceFilterTests
             .FromAssemblyContaining<CustomerService>()
             .InNamespace("Fixtures.SmallProject.Infrastructure", includeSubnamespaces: true)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -55,7 +55,7 @@ public class TypesNamespaceFilterTests
             .FromAssemblyContaining<CustomerService>()
             .InNamespace("Fixtures.SmallProject.Infrastructure")
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Empty(result);
@@ -69,7 +69,7 @@ public class TypesNamespaceFilterTests
             .FromAssemblyContaining<CustomerService>()
             .InSameNamespaceAs(typeof(CustomerService))
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -87,7 +87,7 @@ public class TypesNamespaceFilterTests
             .FromAssemblyContaining<CustomerService>()
             .InSameNamespaceAs<CustomerService>()
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -105,7 +105,7 @@ public class TypesNamespaceFilterTests
             .FromAssemblyContaining<CustomerService>()
             .InSameNamespaceAs<CustomerService>(includeSubnamespaces: true)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -121,7 +121,7 @@ public class TypesNamespaceFilterTests
             .FromAssemblyContaining<CustomerService>()
             .InSameNamespaceAs(typeof(PayPalPaymentGateway), includeSubnamespaces: true)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -139,7 +139,7 @@ public class TypesNamespaceFilterTests
             .Where(t => !t.Name.StartsWith("Stripe"))
             .InSameNamespaceAs<PayPalPaymentGateway>(includeSubnamespaces: true)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesServiceSelectionTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesServiceSelectionTests.cs
@@ -15,7 +15,7 @@ public class TypesServiceSelectionTests
     public void AsSelf_WhenCalled_ShouldRegisterAsImplementationType()
     {
         // Act
-        var result = Types.From(typeof(CustomerService)).AsSelf().Collect();
+        var result = Types.From(typeof(CustomerService)).AsSelf().ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -27,7 +27,7 @@ public class TypesServiceSelectionTests
     public void AsSelf_WithInterface_ShouldRegisterInterfaceAsBothServiceAndImplementation()
     {
         // Act
-        var result = Types.From(typeof(ICustomerService)).AsSelf().Collect();
+        var result = Types.From(typeof(ICustomerService)).AsSelf().ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -39,7 +39,7 @@ public class TypesServiceSelectionTests
     public void AsSelf_WithAbstractClass_ShouldRegisterAbstractClassAsBothServiceAndImplementation()
     {
         // Act
-        var result = Types.From(typeof(RepositoryBase<Customer>)).AsSelf().Collect();
+        var result = Types.From(typeof(RepositoryBase<Customer>)).AsSelf().ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -51,7 +51,7 @@ public class TypesServiceSelectionTests
     public void AsSelf_WithStaticClass_ShouldRegisterStaticClassAsBothServiceAndImplementation()
     {
         // Act
-        var result = Types.From(typeof(PricingDefaults)).AsSelf().Collect();
+        var result = Types.From(typeof(PricingDefaults)).AsSelf().ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -63,7 +63,7 @@ public class TypesServiceSelectionTests
     public void AsAllInterfaces_WhenCalled_ShouldRegisterAllInterfaces()
     {
         // Act
-        var result = Types.From(typeof(PayPalPaymentGateway)).AsAllInterfaces().Collect();
+        var result = Types.From(typeof(PayPalPaymentGateway)).AsAllInterfaces().ToServiceCollection();
 
         // Assert
         var serviceTypes = result.Select(d => d.ServiceType).ToArray();
@@ -75,7 +75,7 @@ public class TypesServiceSelectionTests
     public void AsAllInterfaces_WithInterfaceType_ShouldRegisterParentInterfaces()
     {
         // Act
-        var result = Types.From(typeof(ICustomerRepository)).AsAllInterfaces().Collect();
+        var result = Types.From(typeof(ICustomerRepository)).AsAllInterfaces().ToServiceCollection();
 
         // Assert
         var serviceTypes = result.Select(d => d.ServiceType).ToArray();
@@ -89,7 +89,7 @@ public class TypesServiceSelectionTests
     public void AsAllNonSystemInterfaces_WhenCalled_ShouldExcludeSystemInterfaces()
     {
         // Act
-        var result = Types.From(typeof(PayPalPaymentGateway)).AsAllNonSystemInterfaces().Collect();
+        var result = Types.From(typeof(PayPalPaymentGateway)).AsAllNonSystemInterfaces().ToServiceCollection();
 
         // Assert
         var serviceTypes = result.Select(d => d.ServiceType).ToArray();
@@ -101,7 +101,7 @@ public class TypesServiceSelectionTests
     public void AsAllNonSystemInterfaces_WithInterfaceType_ShouldRegisterNonSystemParentInterfaces()
     {
         // Act
-        var result = Types.From(typeof(ICustomerRepository)).AsAllNonSystemInterfaces().Collect();
+        var result = Types.From(typeof(ICustomerRepository)).AsAllNonSystemInterfaces().ToServiceCollection();
 
         // Assert
         var serviceTypes = result.Select(d => d.ServiceType).ToArray();
@@ -118,7 +118,7 @@ public class TypesServiceSelectionTests
         var result = Types
             .From(typeof(CustomerService), typeof(EmailNotificationSender))
             .AsDefaultInterfaces()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -135,7 +135,7 @@ public class TypesServiceSelectionTests
     public void AsDefaultInterfaces_WhenNoConventionMatch_ShouldNotRegister()
     {
         // Act
-        var result = Types.From(typeof(Customer)).AsDefaultInterfaces().Collect();
+        var result = Types.From(typeof(Customer)).AsDefaultInterfaces().ToServiceCollection();
 
         // Assert
         Assert.Empty(result);
@@ -145,7 +145,7 @@ public class TypesServiceSelectionTests
     public void AsDefaultNonSystemInterfaces_WhenCalled_ShouldCombineBothFilters()
     {
         // Act
-        var result = Types.From(typeof(PayPalPaymentGateway)).AsDefaultNonSystemInterfaces().Collect();
+        var result = Types.From(typeof(PayPalPaymentGateway)).AsDefaultNonSystemInterfaces().ToServiceCollection();
 
         // Assert
         var serviceTypes = result.Select(d => d.ServiceType).ToArray();
@@ -157,7 +157,7 @@ public class TypesServiceSelectionTests
     public void AsFirstInterface_WhenCalled_ShouldRegisterFirstInterface()
     {
         // Act
-        var result = Types.From(typeof(CustomerService)).AsFirstInterface().Collect();
+        var result = Types.From(typeof(CustomerService)).AsFirstInterface().ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -169,7 +169,7 @@ public class TypesServiceSelectionTests
     public void AsFirstInterface_WhenNoInterfaces_ShouldNotRegister()
     {
         // Act
-        var result = Types.From(typeof(Customer)).AsFirstInterface().Collect();
+        var result = Types.From(typeof(Customer)).AsFirstInterface().ToServiceCollection();
 
         // Assert
         Assert.Empty(result);
@@ -179,7 +179,7 @@ public class TypesServiceSelectionTests
     public void AsInterface_WithBasedOn_ShouldRegisterTopLevelDerivedInterfaces()
     {
         // Act
-        var result = Types.From(typeof(SqlCustomerRepository)).BasedOn(typeof(IRepository<>)).AsInterface().Collect();
+        var result = Types.From(typeof(SqlCustomerRepository)).BasedOn(typeof(IRepository<>)).AsInterface().ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -191,7 +191,7 @@ public class TypesServiceSelectionTests
     public void AsInterface_WithGenericTypeArg_ShouldRegisterDerivedInterfaces()
     {
         // Act
-        var result = Types.From(typeof(PayPalPaymentGateway)).AsInterface<IPaymentGateway>().Collect();
+        var result = Types.From(typeof(PayPalPaymentGateway)).AsInterface<IPaymentGateway>().ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -203,7 +203,7 @@ public class TypesServiceSelectionTests
     public void AsInterface_WithExplicitType_ShouldRegisterDerivedInterfaces()
     {
         // Act
-        var result = Types.From(typeof(PayPalPaymentGateway)).AsInterface(typeof(IPaymentGateway)).Collect();
+        var result = Types.From(typeof(PayPalPaymentGateway)).AsInterface(typeof(IPaymentGateway)).ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -215,7 +215,7 @@ public class TypesServiceSelectionTests
     public void AsBase_WithBasedOn_ShouldRegisterAsBaseTypes()
     {
         // Act
-        var result = Types.From(typeof(CustomerService)).BasedOn<ICustomerService>().AsBase().Collect();
+        var result = Types.From(typeof(CustomerService)).BasedOn<ICustomerService>().AsBase().ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -227,7 +227,7 @@ public class TypesServiceSelectionTests
     public void As_WithCustomSelector_ShouldUseProvidedFunction()
     {
         // Act
-        var result = Types.From(typeof(CustomerService)).As(type => type.GetInterfaces()).Collect();
+        var result = Types.From(typeof(CustomerService)).As(type => type.GetInterfaces()).ToServiceCollection();
 
         // Assert
         var serviceTypes = result.Select(d => d.ServiceType).ToArray();
@@ -239,7 +239,7 @@ public class TypesServiceSelectionTests
     public void As_WithBaseTypeContext_ShouldReceiveResolvedBaseTypes()
     {
         // Act
-        var result = Types.From(typeof(CustomerService)).BasedOn<ICustomerService>().As((_, bases) => bases).Collect();
+        var result = Types.From(typeof(CustomerService)).BasedOn<ICustomerService>().As((_, bases) => bases).ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -254,7 +254,7 @@ public class TypesServiceSelectionTests
         var result = Types
             .From(typeof(CustomerService), typeof(OrderService))
             .AsInterfaces(typeof(ICustomerService), typeof(IOrderService))
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -274,7 +274,7 @@ public class TypesServiceSelectionTests
         var result = Types
             .From(typeof(SqlCustomerRepository), typeof(SqlOrderRepository))
             .AsInterfaces(typeof(IRepository<>))
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -291,7 +291,7 @@ public class TypesServiceSelectionTests
     public void AsInterface_WithOpenGenericTypeArg_ShouldRegisterTopLevelDerivedInterfaces()
     {
         // Act
-        var result = Types.From(typeof(SqlCustomerRepository)).AsInterface(typeof(IRepository<>)).Collect();
+        var result = Types.From(typeof(SqlCustomerRepository)).AsInterface(typeof(IRepository<>)).ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesWhereFilterTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesWhereFilterTests.cs
@@ -17,7 +17,7 @@ public class TypesWhereFilterTests
             .From(typeof(CustomerService), typeof(OrderService), typeof(OrderValidator), typeof(PayPalPaymentGateway))
             .Where(t => t.Name.EndsWith("Service"))
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -36,7 +36,7 @@ public class TypesWhereFilterTests
             .Where(t => t.Name.EndsWith("Service"))
             .Where(t => t.Name.StartsWith("Customer"))
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -58,7 +58,7 @@ public class TypesWhereFilterTests
             )
             .Where(t => t.IsInterface)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -81,7 +81,7 @@ public class TypesWhereFilterTests
             )
             .Where(t => t.IsAbstract)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -100,7 +100,7 @@ public class TypesWhereFilterTests
             .From(typeof(Currency), typeof(OrderStatus), typeof(CustomerService), typeof(ICustomerService))
             .Where(t => t.IsValueType)
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -123,9 +123,9 @@ public class TypesWhereFilterTests
         ];
 
         // Act
-        var typesResult = Types.From(types).Where(t => t is { IsClass: true, IsAbstract: false }).AsSelf().Collect();
+        var typesResult = Types.From(types).Where(t => t is { IsClass: true, IsAbstract: false }).AsSelf().ToServiceCollection();
 
-        var classesResult = Classes.From(types).AsSelf().Collect();
+        var classesResult = Classes.From(types).AsSelf().ToServiceCollection();
 
         // Assert
         var typesRegistered = typesResult.Select(d => d.ImplementationType!).OrderBy(t => t.Name).ToArray();
@@ -141,7 +141,7 @@ public class TypesWhereFilterTests
             .From(typeof(CustomerService), typeof(CachingCustomerService), typeof(OrderService), typeof(ProductService))
             .BasedOn<ICustomerService>()
             .AsBase()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var descriptors = result.ToArray();
@@ -165,7 +165,7 @@ public class TypesWhereFilterTests
             )
             .BasedOn(typeof(IValidator<>))
             .AsBase()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var descriptors = result.ToArray();
@@ -188,7 +188,7 @@ public class TypesWhereFilterTests
             .From(typeof(CustomerService), typeof(OrderService), typeof(ProductService), typeof(PayPalPaymentGateway))
             .BasedOn(typeof(ICustomerService), typeof(IOrderService))
             .AsBase()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var implementationTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -207,7 +207,7 @@ public class TypesWhereFilterTests
             .Where(t => !t.Name.StartsWith("Caching"))
             .BasedOn<ICustomerService>()
             .AsBase()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var descriptors = result.ToArray();
@@ -224,7 +224,7 @@ public class TypesWhereFilterTests
             .From(typeof(CustomerService), typeof(ICustomerService), typeof(PricingDefaults))
             .AllTypes()
             .AsSelf()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -243,7 +243,7 @@ public class TypesWhereFilterTests
             .BasedOn<ICustomerService>()
             .BasedOn<IOrderService>()
             .AsBase()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var implementationTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -261,7 +261,7 @@ public class TypesWhereFilterTests
             .BasedOn<ICustomerService>()
             .BasedOn(typeof(IValidator<>))
             .AsBase()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         Assert.Contains(
@@ -282,7 +282,7 @@ public class TypesWhereFilterTests
         var filter = Types.FromAssemblyContaining<CustomerService>().Where(t => t == typeof(CustomerService));
 
         // Act
-        var result = filter.Collect();
+        var result = filter.ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -298,7 +298,7 @@ public class TypesWhereFilterTests
         var filter = Types.From(typeof(CustomerService), typeof(OrderService)).BasedOn<ICustomerService>();
 
         // Act
-        var result = filter.Collect();
+        var result = filter.ToServiceCollection();
 
         // Assert
         var descriptor = Assert.Single(result);
@@ -315,7 +315,7 @@ public class TypesWhereFilterTests
             .From(typeof(ICustomerService), typeof(CustomerService), typeof(OrderService))
             .BasedOn<ICustomerService>()
             .AsBase()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var implementationTypes = result.Select(d => d.ImplementationType).ToArray();
@@ -332,7 +332,7 @@ public class TypesWhereFilterTests
             .From(typeof(RepositoryBase<Customer>), typeof(SqlCustomerRepository), typeof(CustomerService))
             .BasedOn<RepositoryBase<Customer>>()
             .AsBase()
-            .Collect();
+            .ToServiceCollection();
 
         // Assert
         var implementationTypes = result.Select(d => d.ImplementationType).ToArray();

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.UnitTests/ServiceCollectionExtensionsTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.UnitTests/ServiceCollectionExtensionsTests.cs
@@ -138,12 +138,16 @@ public class ServiceCollectionExtensionsTests
         where T : class, IServiceSource
     {
         var mock = Substitute.For<T>();
-        IServiceCollection collection = new ServiceCollection();
-        foreach (var descriptor in descriptors)
-        {
-            collection.Add(descriptor);
-        }
-        mock.Collect().Returns(collection);
+        mock.ToServiceCollection(Arg.Any<IServiceCollection>())
+            .Returns(callInfo =>
+            {
+                var collection = callInfo.Arg<IServiceCollection>();
+                foreach (var descriptor in descriptors)
+                {
+                    collection.Add(descriptor);
+                }
+                return collection;
+            });
         return mock;
     }
 }


### PR DESCRIPTION
Renames an unreleased method `Collect()` to `ToServiceCollection()` and adds an alternative method that adds to an existing service collection: `ToServiceCollection(IServiceCollection serviceCollection)` to avoid the extra allocation. This should be a faster way to register services and probably a better choice for most applications.

Closes #37