### PR TITLE
#35 - Add in all types selecting and clean up a test to use fixtures

### DIFF
--- a/fixtures/CLAUDE.md
+++ b/fixtures/CLAUDE.md
@@ -7,14 +7,15 @@ Unless a test requires a method, property, or field: the classes and interfaces 
 
 A domain-driven design fixture used by the Registration integration tests. Contains types across three layers, each in its own namespace hierarchy under `Fixtures.SmallProject`:
 
-- **`Domain/Entities/`** — `Customer`, `Order`, `OrderItem`, `Product` (classes), `Currency` (struct), `OrderStatus` (enum)
+- **`Domain/Entities/`** — `Customer`, `Order`, `OrderItem`, `Product`, `DigitalProduct : Product`, `SubscriptionProduct : DigitalProduct`, `Invoice` (classes), `Currency` (struct), `OrderStatus` (enum)
 - **`Domain/Repositories/`** — `IReadOnlyRepository<T>`, `IRepository<T>`, `IOrderRepository`, `ICustomerRepository`, `IProductRepository`
 - **`Domain/Services/`** — `IValidator<T>`, `IPricingStrategy`, `OrderValidator`, `CustomerValidator`, `InternalOrderValidator` (internal), `PricingDefaults` (static), `OrderValidator.Strict` (nested)
-- **`Application/Services/`** — `ICustomerService`, `IOrderService`, `IProductService`, `IAuditService`, and their implementations including `AuditServiceDecorator`, `LegacyOrderProcessor`, `CachingCustomerService`
+- **`Domain/Auditing/`** — `IIdentifiable`, `IAuditable : IIdentifiable`, `ISoftDeletable : IIdentifiable`, `AuditableSoftDeletableEntity : IAuditable, ISoftDeletable` (diamond interface mixin pattern)
+- **`Application/Services/`** — `ICustomerService`, `IOrderService`, `IProductService`, `IAuditService`, and their implementations including `AuditServiceDecorator`, `LegacyOrderProcessor`, `CachingCustomerService` (decorated with `[Cacheable("customers")]`)
 - **`Application/Ports/`** — `IEventPublisher`, `IEventPublisher<T>`, `INotificationSender`, `IPaymentGateway`
-- **`Application/Caching/`** — `ICacheProvider`
+- **`Application/Caching/`** — `ICacheProvider`, `ICacheProvider<T>`, `CacheableAttribute`
 - **`Infrastructure/Persistence/`** — `RepositoryBase<T>` (abstract), `InMemoryRepository<T>`, `SqlCustomerRepository`, `SqlOrderRepository`, `SqlRepository<T>`
-- **`Infrastructure/External/`** — `PayPalPaymentGateway`, `StripePaymentGateway`
-- **`Infrastructure/Notifications/`** — `EmailNotificationSender`, `SmsNotificationSender`
+- **`Infrastructure/External/`** — `PayPalPaymentGateway`, `StripePaymentGateway`, `CachingPayPalPaymentGateway : PayPalPaymentGateway`
+- **`Infrastructure/Notifications/`** — `EmailNotificationSender`, `SmsNotificationSender`, `BroadcastNotificationSender` (implements multiple unrelated ports)
 
 The fixture deliberately includes internal types, nested classes, static classes, abstract classes, generics, structs, and enums to exercise the Registration API's visibility filters and type-kind filtering.

--- a/fixtures/Fixtures.SmallProject/Application/Caching/Caching.cs
+++ b/fixtures/Fixtures.SmallProject/Application/Caching/Caching.cs
@@ -3,3 +3,9 @@ namespace Fixtures.SmallProject.Application.Caching;
 public interface ICacheProvider : IDisposable;
 
 public interface ICacheProvider<T> : IAsyncDisposable;
+
+[AttributeUsage(AttributeTargets.Class)]
+public class CacheableAttribute(string region) : Attribute
+{
+    public string Region => region;
+}

--- a/fixtures/Fixtures.SmallProject/Application/Services/Services.cs
+++ b/fixtures/Fixtures.SmallProject/Application/Services/Services.cs
@@ -45,4 +45,5 @@ public class AuditServiceDecorator(IAuditService inner) : IAuditService
 
 public class LegacyOrderProcessor : IOrderService;
 
+[Cacheable("customers")]
 public class CachingCustomerService(ICustomerService inner, ICacheProvider cache) : ICustomerService;

--- a/fixtures/Fixtures.SmallProject/Domain/Auditing/Auditing.cs
+++ b/fixtures/Fixtures.SmallProject/Domain/Auditing/Auditing.cs
@@ -1,0 +1,9 @@
+namespace Fixtures.SmallProject.Domain.Auditing;
+
+public interface IIdentifiable;
+
+public interface IAuditable : IIdentifiable;
+
+public interface ISoftDeletable : IIdentifiable;
+
+public class AuditableSoftDeletableEntity : IAuditable, ISoftDeletable;

--- a/fixtures/Fixtures.SmallProject/Domain/Entities/Entities.cs
+++ b/fixtures/Fixtures.SmallProject/Domain/Entities/Entities.cs
@@ -8,6 +8,12 @@ public class OrderItem;
 
 public class Product;
 
+public class DigitalProduct : Product;
+
+public class SubscriptionProduct : DigitalProduct;
+
+public class Invoice;
+
 public struct Currency;
 
 public enum OrderStatus

--- a/fixtures/Fixtures.SmallProject/Infrastructure/External/External.cs
+++ b/fixtures/Fixtures.SmallProject/Infrastructure/External/External.cs
@@ -11,3 +11,5 @@ public class StripePaymentGateway : IPaymentGateway
 {
     public void Dispose() { }
 }
+
+public class CachingPayPalPaymentGateway : PayPalPaymentGateway;

--- a/fixtures/Fixtures.SmallProject/Infrastructure/Notifications/Notifications.cs
+++ b/fixtures/Fixtures.SmallProject/Infrastructure/Notifications/Notifications.cs
@@ -11,3 +11,8 @@ public class SmsNotificationSender : INotificationSender
 {
     public void Dispose() { }
 }
+
+public class BroadcastNotificationSender : INotificationSender, IEventPublisher
+{
+    public void Dispose() { }
+}

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceSelectorExtensions.Types.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceSelectorExtensions.Types.cs
@@ -1,0 +1,96 @@
+namespace ZCrew.Extensions.DependencyInjection.Registration;
+
+public static partial class ServiceSelectorExtensions
+{
+    extension(IServiceSelector selector)
+    {
+        /// <summary>
+        ///     Registers each type as itself, against all non-abstract classes it extends, and against all interfaces
+        ///     it implements.
+        /// </summary>
+        /// <example>
+        ///     Given <c>CustomerRepository : AbstractRepository, ICustomerRepository, IDisposable</c>:
+        ///     <code>
+        ///     Classes.From(types).AsAllInterfaces()
+        ///     // Registers CustomerRepository as
+        ///     // CustomerRepository, ICustomerRepository and IDisposable
+        ///     // (AbstractRepository is abstract and is excluded)
+        ///     </code>
+        /// </example>
+        public IKeyedServiceSelector AsAllTypes()
+        {
+            return selector.As(type => type.GetTypes().Where(service => !service.IsAbstractClass));
+        }
+
+        /// <summary>
+        ///     Registers each type against all non-abstract classes it extends and interfaces it implements, excluding
+        ///     types in the <c>System</c> namespace and its sub-namespaces.
+        /// </summary>
+        /// <example>
+        ///     Given <c>CustomerRepository : AbstractRepository, ICustomerRepository, IDisposable</c>:
+        ///     <code>
+        ///     Classes.From(types).AsAllNonSystemTypes()
+        ///     // Registers CustomerRepository as CustomerRepository and ICustomerRepository
+        ///     // (IDisposable is in System and is excluded)
+        ///     // (AbstractRepository is abstract and is excluded)
+        ///     </code>
+        /// </example>
+        public IKeyedServiceSelector AsAllNonSystemTypes()
+        {
+            return selector.As(type =>
+                type.GetTypes()
+                    .Where(service => !service.IsAbstractClass)
+                    .Where(service => !service.IsInSameNamespaceAs<object>(includeSubnamespaces: true))
+            );
+        }
+
+        /// <summary>
+        ///     Registers each type against all non-abstract classes it extends and interfaces it implements whose name
+        ///     matches the type name by convention.
+        /// </summary>
+        /// <example>
+        ///     Given <c>CustomerRepository : AbstractRepository, ICustomerRepository, IDisposable</c>:
+        ///     <code>
+        ///     Classes.From(types).AsDefaultTypes()
+        ///     // Registers CustomerRepository as ICustomerRepository
+        ///     // ("CustomerRepository" contains "CustomerRepository" from
+        ///     // "ICustomerRepository", but not "Disposable" nor "AbstractRepository")
+        ///     // (AbstractRepository is abstract and is excluded for a second reason)
+        ///     </code>
+        /// </example>
+        public IKeyedServiceSelector AsDefaultTypes()
+        {
+            return selector.As(type =>
+                type.GetTypes()
+                    .Where(service => !service.IsAbstractClass)
+                    .Where(service => type.Name.Contains(service.GetInterfaceName()))
+            );
+        }
+
+        /// <summary>
+        ///     Registers each type against all non-abstract classes it extends and interfaces it implements whose name
+        ///     matches the type name by convention, excluding types in the <c>System</c> namespace and its
+        ///     sub-namespaces.
+        /// </summary>
+        /// <example>
+        ///     Given <c>CustomerRepository : AbstractRepository, ICustomerRepository, IDisposable</c>:
+        ///     <code>
+        ///     Classes.From(types).AsDefaultTypes()
+        ///     // Registers CustomerRepository as ICustomerRepository
+        ///     // ("CustomerRepository" contains "CustomerRepository" from
+        ///     // "ICustomerRepository", but not "Disposable" nor "AbstractRepository")
+        ///     // (IDisposable is in System and is excluded for a second reason)
+        ///     // (AbstractRepository is abstract and is excluded for a second reason)
+        ///     </code>
+        /// </example>
+        public IKeyedServiceSelector AsDefaultNonSystemTypes()
+        {
+            return selector.As(type =>
+                type.GetTypes()
+                    .Where(service => !service.IsAbstractClass)
+                    .Where(service => type.Name.Contains(service.GetInterfaceName()))
+                    .Where(service => !service.IsInSameNamespaceAs<object>(includeSubnamespaces: true))
+            );
+        }
+    }
+}

--- a/src/ZCrew.Extensions.DependencyInjection/TypeExtensions.cs
+++ b/src/ZCrew.Extensions.DependencyInjection/TypeExtensions.cs
@@ -11,6 +11,15 @@ public static class TypeExtensions
     extension(Type type)
     {
         /// <summary>
+        ///     Combines the <see cref="Type.IsAbstract"/> and <see cref="Type.IsInterface"/> to check if a type is
+        ///     abstract and not an interface.
+        /// </summary>
+        public bool IsAbstractClass
+        {
+            get => type is { IsAbstract: true, IsInterface: false };
+        }
+
+        /// <summary>
         ///     Returns <see langword="true"/> if the type has the specified attribute applied.
         /// </summary>
         /// <typeparam name="TAttribute">The attribute type to check for.</typeparam>
@@ -31,6 +40,31 @@ public static class TypeExtensions
         {
             var attribute = type.GetTypeInfo().GetCustomAttribute<TAttribute>();
             return attribute != null && filter(attribute);
+        }
+
+        /// <summary>
+        ///     Returns the type itself, all classes the current type extends, and all interfaces the current type
+        ///     implements.
+        /// </summary>
+        /// <returns>The list of all types the current type represents.</returns>
+        public IEnumerable<Type> GetTypes()
+        {
+            // Every type is itself
+            yield return type;
+
+            // And all base types
+            var baseType = type.BaseType;
+            while (baseType != null)
+            {
+                yield return baseType;
+                baseType = baseType.BaseType;
+            }
+
+            // And all interfaces
+            foreach (var @interface in type.GetInterfaces())
+            {
+                yield return @interface;
+            }
         }
 
         /// <summary>

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesServiceSelectionTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesServiceSelectionTests.cs
@@ -90,6 +90,131 @@ public class ClassesServiceSelectionTests
     }
 
     [Fact]
+    public void AsAllTypes_WhenCalled_ShouldRegisterTypeAndNonAbstractBaseClassesAndInterfaces()
+    {
+        // Act
+        var result = Classes.From(typeof(SqlCustomerRepository)).AsAllTypes().ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(SqlCustomerRepository), serviceTypes);
+        Assert.Contains(typeof(ICustomerRepository), serviceTypes);
+        Assert.Contains(typeof(IDisposable), serviceTypes);
+        Assert.DoesNotContain(typeof(RepositoryBase<Customer>), serviceTypes);
+    }
+
+    [Fact]
+    public void AsAllNonSystemTypes_WhenCalled_ShouldExcludeSystemTypesAndAbstractBaseClasses()
+    {
+        // Act
+        var result = Classes.From(typeof(SqlCustomerRepository)).AsAllNonSystemTypes().ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(SqlCustomerRepository), serviceTypes);
+        Assert.Contains(typeof(ICustomerRepository), serviceTypes);
+        Assert.DoesNotContain(typeof(IDisposable), serviceTypes);
+        Assert.DoesNotContain(typeof(IAsyncDisposable), serviceTypes);
+        Assert.DoesNotContain(typeof(object), serviceTypes);
+        Assert.DoesNotContain(typeof(RepositoryBase<Customer>), serviceTypes);
+    }
+
+    [Fact]
+    public void AsDefaultTypes_WhenCalled_ShouldMatchByNamingConvention()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(CustomerService), typeof(EmailNotificationSender))
+            .AsDefaultTypes()
+            .ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(ICustomerService), serviceTypes);
+        Assert.Contains(typeof(INotificationSender), serviceTypes);
+    }
+
+    [Fact]
+    public void AsDefaultTypes_WhenTypeHasNoBaseOrInterfaceMatchingConvention_ShouldRegisterOnlySelf()
+    {
+        // Act
+        var result = Classes.From(typeof(Customer)).AsDefaultTypes().ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(Customer), serviceTypes);
+        Assert.DoesNotContain(typeof(object), serviceTypes);
+    }
+
+    [Fact]
+    public void AsDefaultNonSystemTypes_WhenCalled_ShouldCombineBothFilters()
+    {
+        // Act
+        var result = Classes.From(typeof(SqlCustomerRepository)).AsDefaultNonSystemTypes().ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(ICustomerRepository), serviceTypes);
+        Assert.DoesNotContain(typeof(IDisposable), serviceTypes);
+        Assert.DoesNotContain(typeof(IAsyncDisposable), serviceTypes);
+        Assert.DoesNotContain(typeof(RepositoryBase<Customer>), serviceTypes);
+    }
+
+    [Fact]
+    public void AsAllTypes_WhenTypeExtendsConcreteBase_ShouldRegisterAgainstBaseAndInheritedInterfaces()
+    {
+        // Act
+        var result = Classes.From(typeof(CachingPayPalPaymentGateway)).AsAllTypes().ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(CachingPayPalPaymentGateway), serviceTypes);
+        Assert.Contains(typeof(PayPalPaymentGateway), serviceTypes);
+        Assert.Contains(typeof(IPaymentGateway), serviceTypes);
+        Assert.Contains(typeof(IDisposable), serviceTypes);
+    }
+
+    [Fact]
+    public void AsAllNonSystemTypes_WhenTypeExtendsConcreteBase_ShouldExcludeSystemInheritedInterfaces()
+    {
+        // Act
+        var result = Classes.From(typeof(CachingPayPalPaymentGateway)).AsAllNonSystemTypes().ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(CachingPayPalPaymentGateway), serviceTypes);
+        Assert.Contains(typeof(PayPalPaymentGateway), serviceTypes);
+        Assert.Contains(typeof(IPaymentGateway), serviceTypes);
+        Assert.DoesNotContain(typeof(IDisposable), serviceTypes);
+        Assert.DoesNotContain(typeof(object), serviceTypes);
+    }
+
+    [Fact]
+    public void AsDefaultTypes_WhenBaseClassNameMatchesConvention_ShouldRegisterAgainstBase()
+    {
+        // Act
+        var result = Classes.From(typeof(CachingPayPalPaymentGateway)).AsDefaultTypes().ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(PayPalPaymentGateway), serviceTypes);
+        Assert.Contains(typeof(IPaymentGateway), serviceTypes);
+    }
+
+    [Fact]
+    public void AsDefaultNonSystemTypes_WhenBaseClassNameMatchesConvention_ShouldRegisterAgainstBase()
+    {
+        // Act
+        var result = Classes.From(typeof(CachingPayPalPaymentGateway)).AsDefaultNonSystemTypes().ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(PayPalPaymentGateway), serviceTypes);
+        Assert.Contains(typeof(IPaymentGateway), serviceTypes);
+        Assert.DoesNotContain(typeof(IDisposable), serviceTypes);
+    }
+
+    [Fact]
     public void AsFirstInterface_WhenCalled_ShouldRegisterFirstInterface()
     {
         // Act

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesServiceSelectionTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesServiceSelectionTests.cs
@@ -154,6 +154,131 @@ public class TypesServiceSelectionTests
     }
 
     [Fact]
+    public void AsAllTypes_WhenCalled_ShouldRegisterTypeAndNonAbstractBaseClassesAndInterfaces()
+    {
+        // Act
+        var result = Types.From(typeof(SqlCustomerRepository)).AsAllTypes().ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(SqlCustomerRepository), serviceTypes);
+        Assert.Contains(typeof(ICustomerRepository), serviceTypes);
+        Assert.Contains(typeof(IDisposable), serviceTypes);
+        Assert.DoesNotContain(typeof(RepositoryBase<Customer>), serviceTypes);
+    }
+
+    [Fact]
+    public void AsAllNonSystemTypes_WhenCalled_ShouldExcludeSystemTypesAndAbstractBaseClasses()
+    {
+        // Act
+        var result = Types.From(typeof(SqlCustomerRepository)).AsAllNonSystemTypes().ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(SqlCustomerRepository), serviceTypes);
+        Assert.Contains(typeof(ICustomerRepository), serviceTypes);
+        Assert.DoesNotContain(typeof(IDisposable), serviceTypes);
+        Assert.DoesNotContain(typeof(IAsyncDisposable), serviceTypes);
+        Assert.DoesNotContain(typeof(object), serviceTypes);
+        Assert.DoesNotContain(typeof(RepositoryBase<Customer>), serviceTypes);
+    }
+
+    [Fact]
+    public void AsDefaultTypes_WhenCalled_ShouldMatchByNamingConvention()
+    {
+        // Act
+        var result = Types
+            .From(typeof(CustomerService), typeof(EmailNotificationSender))
+            .AsDefaultTypes()
+            .ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(ICustomerService), serviceTypes);
+        Assert.Contains(typeof(INotificationSender), serviceTypes);
+    }
+
+    [Fact]
+    public void AsDefaultTypes_WhenTypeHasNoBaseOrInterfaceMatchingConvention_ShouldRegisterOnlySelf()
+    {
+        // Act
+        var result = Types.From(typeof(Customer)).AsDefaultTypes().ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(Customer), serviceTypes);
+        Assert.DoesNotContain(typeof(object), serviceTypes);
+    }
+
+    [Fact]
+    public void AsDefaultNonSystemTypes_WhenCalled_ShouldCombineBothFilters()
+    {
+        // Act
+        var result = Types.From(typeof(SqlCustomerRepository)).AsDefaultNonSystemTypes().ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(ICustomerRepository), serviceTypes);
+        Assert.DoesNotContain(typeof(IDisposable), serviceTypes);
+        Assert.DoesNotContain(typeof(IAsyncDisposable), serviceTypes);
+        Assert.DoesNotContain(typeof(RepositoryBase<Customer>), serviceTypes);
+    }
+
+    [Fact]
+    public void AsAllTypes_WhenTypeExtendsConcreteBase_ShouldRegisterAgainstBaseAndInheritedInterfaces()
+    {
+        // Act
+        var result = Types.From(typeof(CachingPayPalPaymentGateway)).AsAllTypes().ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(CachingPayPalPaymentGateway), serviceTypes);
+        Assert.Contains(typeof(PayPalPaymentGateway), serviceTypes);
+        Assert.Contains(typeof(IPaymentGateway), serviceTypes);
+        Assert.Contains(typeof(IDisposable), serviceTypes);
+    }
+
+    [Fact]
+    public void AsAllNonSystemTypes_WhenTypeExtendsConcreteBase_ShouldExcludeSystemInheritedInterfaces()
+    {
+        // Act
+        var result = Types.From(typeof(CachingPayPalPaymentGateway)).AsAllNonSystemTypes().ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(CachingPayPalPaymentGateway), serviceTypes);
+        Assert.Contains(typeof(PayPalPaymentGateway), serviceTypes);
+        Assert.Contains(typeof(IPaymentGateway), serviceTypes);
+        Assert.DoesNotContain(typeof(IDisposable), serviceTypes);
+        Assert.DoesNotContain(typeof(object), serviceTypes);
+    }
+
+    [Fact]
+    public void AsDefaultTypes_WhenBaseClassNameMatchesConvention_ShouldRegisterAgainstBase()
+    {
+        // Act
+        var result = Types.From(typeof(CachingPayPalPaymentGateway)).AsDefaultTypes().ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(PayPalPaymentGateway), serviceTypes);
+        Assert.Contains(typeof(IPaymentGateway), serviceTypes);
+    }
+
+    [Fact]
+    public void AsDefaultNonSystemTypes_WhenBaseClassNameMatchesConvention_ShouldRegisterAgainstBase()
+    {
+        // Act
+        var result = Types.From(typeof(CachingPayPalPaymentGateway)).AsDefaultNonSystemTypes().ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(PayPalPaymentGateway), serviceTypes);
+        Assert.Contains(typeof(IPaymentGateway), serviceTypes);
+        Assert.DoesNotContain(typeof(IDisposable), serviceTypes);
+    }
+
+    [Fact]
     public void AsFirstInterface_WhenCalled_ShouldRegisterFirstInterface()
     {
         // Act

--- a/tests/ZCrew.Extensions.DependencyInjection.UnitTests/TypeExtensionsTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.UnitTests/TypeExtensionsTests.cs
@@ -1,3 +1,13 @@
+using Fixtures.SmallProject.Application.Caching;
+using Fixtures.SmallProject.Application.Ports;
+using Fixtures.SmallProject.Application.Services;
+using Fixtures.SmallProject.Domain.Auditing;
+using Fixtures.SmallProject.Domain.Entities;
+using Fixtures.SmallProject.Domain.Repositories;
+using Fixtures.SmallProject.Domain.Services;
+using Fixtures.SmallProject.Infrastructure.Notifications;
+using Fixtures.SmallProject.Infrastructure.Persistence;
+
 namespace ZCrew.Extensions.DependencyInjection.UnitTests;
 
 public class TypeExtensionsTests
@@ -6,7 +16,7 @@ public class TypeExtensionsTests
     public void HasAttribute_WhenTypeHasAttribute_ShouldReturnTrue()
     {
         // Act
-        var result = typeof(DecoratedType).HasAttribute<TestAttribute>();
+        var result = typeof(CachingCustomerService).HasAttribute<CacheableAttribute>();
 
         // Assert
         Assert.True(result);
@@ -16,7 +26,7 @@ public class TypeExtensionsTests
     public void HasAttribute_WhenTypeDoesNotHaveAttribute_ShouldReturnFalse()
     {
         // Act
-        var result = typeof(PlainType).HasAttribute<TestAttribute>();
+        var result = typeof(Customer).HasAttribute<CacheableAttribute>();
 
         // Assert
         Assert.False(result);
@@ -26,7 +36,7 @@ public class TypeExtensionsTests
     public void HasAttribute_WithFilter_WhenAttributeMatchesFilter_ShouldReturnTrue()
     {
         // Act
-        var result = typeof(DecoratedType).HasAttribute<TestAttribute>(a => a.Value == "hello");
+        var result = typeof(CachingCustomerService).HasAttribute<CacheableAttribute>(a => a.Region == "customers");
 
         // Assert
         Assert.True(result);
@@ -36,7 +46,7 @@ public class TypeExtensionsTests
     public void HasAttribute_WithFilter_WhenAttributeDoesNotMatchFilter_ShouldReturnFalse()
     {
         // Act
-        var result = typeof(DecoratedType).HasAttribute<TestAttribute>(a => a.Value == "world");
+        var result = typeof(CachingCustomerService).HasAttribute<CacheableAttribute>(a => a.Region == "products");
 
         // Assert
         Assert.False(result);
@@ -46,10 +56,50 @@ public class TypeExtensionsTests
     public void HasAttribute_WithFilter_WhenTypeDoesNotHaveAttribute_ShouldReturnFalse()
     {
         // Act
-        var result = typeof(PlainType).HasAttribute<TestAttribute>(a => a.Value == "hello");
+        var result = typeof(Customer).HasAttribute<CacheableAttribute>(a => a.Region == "customers");
 
         // Assert
         Assert.False(result);
+    }
+
+    [Fact]
+    public void IsAbstractClass_WhenAbstractClass_ShouldReturnTrue()
+    {
+        // Act
+        var result = typeof(RepositoryBase<Customer>).IsAbstractClass;
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsAbstractClass_WhenInterface_ShouldReturnFalse()
+    {
+        // Act
+        var result = typeof(ICustomerRepository).IsAbstractClass;
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsAbstractClass_WhenConcreteClass_ShouldReturnFalse()
+    {
+        // Act
+        var result = typeof(SqlCustomerRepository).IsAbstractClass;
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsAbstractClass_WhenStaticClass_ShouldReturnTrue()
+    {
+        // Act
+        var result = typeof(PricingDefaults).IsAbstractClass;
+
+        // Assert
+        Assert.True(result);
     }
 
     [Fact]
@@ -176,60 +226,60 @@ public class TypeExtensionsTests
     public void GetInterfaceName_WhenHasConventionalIPrefix_ShouldStripPrefix()
     {
         // Act
-        var result = typeof(IMyService).GetInterfaceName();
+        var result = typeof(ICustomerService).GetInterfaceName();
 
         // Assert
-        Assert.Equal("MyService", result);
+        Assert.Equal("CustomerService", result);
     }
 
     [Fact]
     public void GetInterfaceName_WhenNoIPrefix_ShouldReturnUnchanged()
     {
         // Act
-        var result = typeof(PlainType).GetInterfaceName();
+        var result = typeof(Customer).GetInterfaceName();
 
         // Assert
-        Assert.Equal("PlainType", result);
+        Assert.Equal("Customer", result);
     }
 
     [Fact]
     public void GetInterfaceName_WhenSecondCharIsLowercase_ShouldReturnUnchanged()
     {
         // Act
-        var result = typeof(Items).GetInterfaceName();
+        var result = typeof(Invoice).GetInterfaceName();
 
         // Assert
-        Assert.Equal("Items", result);
+        Assert.Equal("Invoice", result);
     }
 
     [Fact]
     public void GetTopLevelInterfaces_WhenHierarchy_ShouldReturnOnlyMostDerived()
     {
         // Act
-        var result = typeof(DerivedImpl).GetTopLevelInterfaces().ToList();
+        var result = typeof(SqlCustomerRepository).GetTopLevelInterfaces().ToList();
 
         // Assert
         Assert.Single(result);
-        Assert.Contains(typeof(IDerived), result);
+        Assert.Contains(typeof(ICustomerRepository), result);
     }
 
     [Fact]
     public void GetTopLevelInterfaces_WhenMultipleUnrelated_ShouldReturnAll()
     {
         // Act
-        var result = typeof(MultiImpl).GetTopLevelInterfaces().ToList();
+        var result = typeof(BroadcastNotificationSender).GetTopLevelInterfaces().ToList();
 
         // Assert
         Assert.Equal(2, result.Count);
-        Assert.Contains(typeof(IFirst), result);
-        Assert.Contains(typeof(ISecond), result);
+        Assert.Contains(typeof(INotificationSender), result);
+        Assert.Contains(typeof(IEventPublisher), result);
     }
 
     [Fact]
     public void GetTopLevelInterfaces_WhenNoInterfaces_ShouldReturnEmpty()
     {
         // Act
-        var result = typeof(PlainType).GetTopLevelInterfaces();
+        var result = typeof(Customer).GetTopLevelInterfaces();
 
         // Assert
         Assert.Empty(result);
@@ -239,47 +289,88 @@ public class TypeExtensionsTests
     public void GetTopLevelInterfaces_WhenDiamondHierarchy_ShouldReturnOnlyLeaves()
     {
         // Act
-        var result = typeof(DiamondImpl).GetTopLevelInterfaces().ToList();
+        var result = typeof(AuditableSoftDeletableEntity).GetTopLevelInterfaces().ToList();
 
         // Assert
         Assert.Equal(2, result.Count);
-        Assert.Contains(typeof(IDiamondLeft), result);
-        Assert.Contains(typeof(IDiamondRight), result);
-        Assert.DoesNotContain(typeof(IDiamondBase), result);
+        Assert.Contains(typeof(IAuditable), result);
+        Assert.Contains(typeof(ISoftDeletable), result);
+        Assert.DoesNotContain(typeof(IIdentifiable), result);
     }
 
-    [AttributeUsage(AttributeTargets.Class)]
-    private class TestAttribute(string value) : Attribute
+    [Fact]
+    public void GetTypes_OnConcreteClassWithBaseAndInterface_ShouldReturnTypeItselfBaseClassesAndInterfaces()
     {
-        public string Value => value;
+        // Act
+        var result = typeof(SqlCustomerRepository).GetTypes().ToList();
+
+        // Assert
+        Assert.Contains(typeof(SqlCustomerRepository), result);
+        Assert.Contains(typeof(RepositoryBase<Customer>), result);
+        Assert.Contains(typeof(object), result);
+        Assert.Contains(typeof(ICustomerRepository), result);
+        Assert.Contains(typeof(IRepository<Customer>), result);
+        Assert.Contains(typeof(IReadOnlyRepository<Customer>), result);
+        Assert.Contains(typeof(IDisposable), result);
+        Assert.Contains(typeof(IAsyncDisposable), result);
     }
 
-    [Test("hello")]
-    private class DecoratedType;
+    [Fact]
+    public void GetTypes_WhenBaseClassIsAbstract_ShouldIncludeAbstractBaseClasses()
+    {
+        // Act
+        var result = typeof(SqlCustomerRepository).GetTypes().ToList();
 
-    private class PlainType;
+        // Assert
+        Assert.Contains(typeof(RepositoryBase<Customer>), result);
+    }
 
-    private class Items;
+    [Fact]
+    public void GetTypes_WhenCalled_ShouldIncludeObjectBaseType()
+    {
+        // Act
+        var result = typeof(SqlCustomerRepository).GetTypes().ToList();
 
-    private interface IMyService;
+        // Assert
+        Assert.Contains(typeof(object), result);
+    }
 
-    private interface IBase;
+    [Fact]
+    public void GetTypes_OnTypeWithNoBaseOrInterfaces_ShouldReturnTypeItselfAndObject()
+    {
+        // Act
+        var result = typeof(Customer).GetTypes().ToList();
 
-    private interface IDerived : IBase;
+        // Assert
+        Assert.Equal(new[] { typeof(Customer), typeof(object) }, result);
+    }
 
-    private class DerivedImpl : IDerived;
+    [Fact]
+    public void GetTypes_OnTypeWithMultipleBaseClasses_ShouldReturnFullChainInOrder()
+    {
+        // Act
+        var result = typeof(SubscriptionProduct).GetTypes().ToList();
 
-    private interface IFirst;
+        // Assert
+        Assert.Equal(
+            new[] { typeof(SubscriptionProduct), typeof(DigitalProduct), typeof(Product), typeof(object) },
+            result
+        );
+    }
 
-    private interface ISecond;
+    [Fact]
+    public void GetTypes_OnInterface_ShouldReturnInterfaceItselfAndInheritedInterfaces()
+    {
+        // Act
+        var result = typeof(ICustomerRepository).GetTypes().ToList();
 
-    private class MultiImpl : IFirst, ISecond;
+        // Assert
+        Assert.Contains(typeof(ICustomerRepository), result);
+        Assert.Contains(typeof(IRepository<Customer>), result);
+        Assert.Contains(typeof(IReadOnlyRepository<Customer>), result);
+        Assert.Contains(typeof(IDisposable), result);
+        Assert.Contains(typeof(IAsyncDisposable), result);
+        Assert.DoesNotContain(typeof(object), result);
+    }
 
-    private interface IDiamondBase;
-
-    private interface IDiamondLeft : IDiamondBase;
-
-    private interface IDiamondRight : IDiamondBase;
-
-    private class DiamondImpl : IDiamondLeft, IDiamondRight;
 }


### PR DESCRIPTION
Add in all types selecting with:

- `AsAllTypes`
- `AsAllNonSystemTypes`
- `AsDefaultTypes`
- `AsDefaultNonSystemTypes`

That register all types (including the type itself) excluding abstract classes

Closes #35