### PR TITLE
#42 - Add HasAttribute type filter

### DIFF
--- a/docs/registration.md
+++ b/docs/registration.md
@@ -31,7 +31,7 @@ The API is a fluent chain with six stages:
 
 1. **Entry point** — Choose where types come from (`Classes` for non-abstract classes, `Types` for everything)
 2. **Type selection** — Optionally control assembly visibility (`IncludeInternalTypes`, `IncludeAllTypes`)
-3. **Type filtering** — Narrow down which types to register (`Where`, `BasedOn`, `InNamespace`)
+3. **Type filtering** — Narrow down which types to register (`Where`, `BasedOn`, `InNamespace`, `HasAttribute`)
 4. **Service selection** — Decide what service type each implementation registers as (`AsInterface`, `AsDefaultInterfaces`, `AsSelf`, etc.)
 5. **Keyed service selection** — Optionally assign service keys via `Keyed`
 6. **Lifetime selection** — Optionally choose a lifetime and sharing mode (`AsSingleton`, `AsScoped`, `AsTransient`, `AsSingletonDependent`, …); defaults to `Singleton` + `SharedComponent`
@@ -110,6 +110,69 @@ services.AddTransient(
         .AsBase()
 );
 ```
+
+### Filter by attribute
+
+`HasAttribute` narrows to types decorated with a given attribute — handy for opt-in registration:
+
+```csharp
+services.AddSingleton(
+    Classes.FromThisAssembly()
+        .HasAttribute<ServiceAttribute>()
+        .AsInterface()
+);
+```
+
+Pass a condition to filter on the attribute's data:
+
+```csharp
+services.AddSingleton(
+    Classes.FromThisAssembly()
+        .HasAttribute<CacheableAttribute>(attr => attr.Region == "customers")
+        .AsSelf()
+);
+```
+
+The attribute type may also be a **marker interface** that several attributes implement. Matching is by
+assignability, so this catches any attribute assignable to the interface — and lets you filter on a property
+the interface defines:
+
+```csharp
+public interface IRegionAware { string Region { get; } }
+
+[AttributeUsage(AttributeTargets.Class)]
+public class CacheableAttribute(string region) : Attribute, IRegionAware
+{
+    public string Region => region;
+}
+
+[AttributeUsage(AttributeTargets.Class)]
+public class PartitionedAttribute(string region) : Attribute, IRegionAware
+{
+    public string Region => region;
+}
+
+// Matches types carrying *either* attribute, filtered by the shared Region property:
+services.AddSingleton(
+    Classes.FromThisAssembly()
+        .HasAttribute<IRegionAware>(a => a.Region == "customers")
+        .AsSelf()
+);
+```
+
+When a type can carry **multiple** instances of an attribute (`AllowMultiple = true`), use `HasAttributes`
+(plural) to evaluate the whole set at once:
+
+```csharp
+services.AddSingleton(
+    Classes.FromThisAssembly()
+        .HasAttributes<TagAttribute>(tags => tags.Any(t => t.Name == "public"))
+        .AsSelf()
+);
+```
+
+Both `HasAttribute` and `HasAttributes` also have a non-generic `Type` overload and an optional `inherited`
+flag that controls whether attributes inherited from base types are considered.
 
 ## Entry points: `Classes` vs `Types`
 

--- a/fixtures/Fixtures.SmallProject/Attributes/AttributeFixtures.cs
+++ b/fixtures/Fixtures.SmallProject/Attributes/AttributeFixtures.cs
@@ -1,0 +1,97 @@
+namespace Fixtures.SmallProject.Attributes;
+
+/// <summary>
+///     Marker interface implemented by several attributes. Exercises attribute filtering by an interface the
+///     attribute implements (rather than by the concrete attribute type), including reading a property the
+///     interface defines.
+/// </summary>
+public interface IRegionAware
+{
+    string Region { get; }
+}
+
+[AttributeUsage(AttributeTargets.Class)]
+public class RegionCacheAttribute(string region) : Attribute, IRegionAware
+{
+    public string Region => region;
+}
+
+[AttributeUsage(AttributeTargets.Class)]
+public class RegionPartitionAttribute(string region) : Attribute, IRegionAware
+{
+    public string Region => region;
+}
+
+[RegionCache("customers")]
+public class RegionalCustomerStore;
+
+[RegionCache("orders")]
+public class RegionalOrderStore;
+
+[RegionPartition("payments")]
+public class PartitionedPaymentStore;
+
+public class UnmarkedStore;
+
+/// <summary>
+///     Default <see cref="AttributeUsageAttribute"/> — <c>Inherited = true</c> — so derived types match when requested.
+///     Carries data so it also exercises the inherited condition overloads.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class)]
+public class TracedAttribute(string channel) : Attribute
+{
+    public string Channel => channel;
+}
+
+[Traced("audit")]
+public class TracedBase;
+
+public class TracedDerived : TracedBase;
+
+/// <summary><c>Inherited = false</c> — derived types never match, even when inherited attributes are requested.</summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public class LocalOnlyAttribute : Attribute;
+
+[LocalOnly]
+public class LocalOnlyBase;
+
+public class LocalOnlyDerived : LocalOnlyBase;
+
+/// <summary><c>AllowMultiple = true</c> — a type may carry several instances, exercising the collection conditions.</summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public class TagAttribute(string name) : Attribute
+{
+    public string Name => name;
+}
+
+[Tag("a")]
+[Tag("b")]
+public class MultiTagged;
+
+[Tag("only")]
+public class SingleTagged;
+
+[Tag("base1")]
+[Tag("base2")]
+public class TaggedBase;
+
+public class TaggedDerived : TaggedBase;
+
+/// <summary>Applicable to every type kind, so it can decorate an interface, struct, and enum for type-kind coverage.</summary>
+[AttributeUsage(AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Class)]
+public class MetaAttribute : Attribute;
+
+[Meta]
+public interface IMarkedContract;
+
+[Meta]
+public struct MarkedValue;
+
+[Meta]
+public enum MarkedEnum
+{
+    None,
+}
+
+[Meta]
+public class MarkedClass;

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceSelector.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceSelector.cs
@@ -1,5 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
-
 namespace ZCrew.Extensions.DependencyInjection.Registration;
 
 /// <summary>

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/TypeFilter.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/TypeFilter.cs
@@ -1,5 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
-
 namespace ZCrew.Extensions.DependencyInjection.Registration;
 
 /// <summary>

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/TypeFilterExtensions.Attribute.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/TypeFilterExtensions.Attribute.cs
@@ -1,0 +1,204 @@
+namespace ZCrew.Extensions.DependencyInjection.Registration;
+
+public static partial class TypeFilterExtensions
+{
+    extension(TypeFilter filter)
+    {
+        /// <summary>
+        ///     Filters to types decorated with an attribute assignable to <paramref name="attributeType"/>,
+        ///     including inherited attributes. The type may be a concrete attribute type or an interface
+        ///     implemented by one or more attributes.
+        /// </summary>
+        /// <param name="attributeType">The attribute type or marker interface to search for.</param>
+        public TypeFilter HasAttribute(Type attributeType)
+        {
+            return filter.HasAttribute(attributeType, inherited: true);
+        }
+
+        /// <summary>
+        ///     Filters to types decorated with an attribute assignable to <typeparamref name="TAttribute"/>,
+        ///     including inherited attributes. <typeparamref name="TAttribute"/> may be a concrete attribute
+        ///     type or an interface implemented by one or more attributes.
+        /// </summary>
+        /// <typeparam name="TAttribute">The attribute type or marker interface to search for.</typeparam>
+        public TypeFilter HasAttribute<TAttribute>()
+            where TAttribute : class
+        {
+            return filter.HasAttribute<TAttribute>(inherited: true);
+        }
+
+        /// <summary>
+        ///     Filters to types decorated with an attribute assignable to <paramref name="attributeType"/>.
+        ///     The type may be a concrete attribute type or an interface implemented by one or more attributes.
+        /// </summary>
+        /// <param name="attributeType">The attribute type or marker interface to search for.</param>
+        /// <param name="inherited">
+        ///     <see langword="true"/> to inspect the ancestors of the type; otherwise, <see langword="false"/>.
+        /// </param>
+        public TypeFilter HasAttribute(Type attributeType, bool inherited)
+        {
+            ValidateAttributeType(attributeType);
+            return filter.Where(type => type.GetCustomAttributes(inherited).Any(attributeType.IsInstanceOfType));
+        }
+
+        /// <summary>
+        ///     Filters to types decorated with an attribute assignable to <typeparamref name="TAttribute"/>.
+        ///     <typeparamref name="TAttribute"/> may be a concrete attribute type or an interface implemented
+        ///     by one or more attributes.
+        /// </summary>
+        /// <param name="inherited">
+        ///     <see langword="true"/> to inspect the ancestors of the type; otherwise, <see langword="false"/>.
+        /// </param>
+        /// <typeparam name="TAttribute">The attribute type or marker interface to search for.</typeparam>
+        public TypeFilter HasAttribute<TAttribute>(bool inherited)
+            where TAttribute : class
+        {
+            ValidateAttributeType(typeof(TAttribute));
+            return filter.Where(type => type.GetCustomAttributes(inherited).OfType<TAttribute>().Any());
+        }
+
+        /// <summary>
+        ///     Filters to types decorated with an attribute assignable to <paramref name="attributeType"/>
+        ///     that satisfies <paramref name="condition"/>, including inherited attributes.
+        /// </summary>
+        /// <param name="attributeType">The attribute type or marker interface to search for.</param>
+        /// <param name="condition">The additional condition to evaluate on a matching attribute.</param>
+        public TypeFilter HasAttribute(Type attributeType, Func<Attribute, bool> condition)
+        {
+            ArgumentNullException.ThrowIfNull(condition);
+            return filter.HasAttributes(attributeType, attributes => attributes.Any(condition));
+        }
+
+        /// <summary>
+        ///     Filters to types decorated with an attribute assignable to <typeparamref name="TAttribute"/>
+        ///     that satisfies <paramref name="condition"/>, including inherited attributes.
+        /// </summary>
+        /// <param name="condition">The additional condition to evaluate on a matching attribute.</param>
+        /// <typeparam name="TAttribute">The attribute type or marker interface to search for.</typeparam>
+        public TypeFilter HasAttribute<TAttribute>(Func<TAttribute, bool> condition)
+            where TAttribute : class
+        {
+            ArgumentNullException.ThrowIfNull(condition);
+            return filter.HasAttributes<TAttribute>(attributes => attributes.Any(condition));
+        }
+
+        /// <summary>
+        ///     Filters to types decorated with an attribute assignable to <paramref name="attributeType"/>
+        ///     that satisfies <paramref name="condition"/>.
+        /// </summary>
+        /// <param name="attributeType">The attribute type or marker interface to search for.</param>
+        /// <param name="inherited">
+        ///     <see langword="true"/> to inspect the ancestors of the type; otherwise, <see langword="false"/>.
+        /// </param>
+        /// <param name="condition">The additional condition to evaluate on a matching attribute.</param>
+        public TypeFilter HasAttribute(Type attributeType, bool inherited, Func<Attribute, bool> condition)
+        {
+            ArgumentNullException.ThrowIfNull(condition);
+            return filter.HasAttributes(attributeType, inherited, attributes => attributes.Any(condition));
+        }
+
+        /// <summary>
+        ///     Filters to types decorated with an attribute assignable to <typeparamref name="TAttribute"/>
+        ///     that satisfies <paramref name="condition"/>.
+        /// </summary>
+        /// <param name="inherited">
+        ///     <see langword="true"/> to inspect the ancestors of the type; otherwise, <see langword="false"/>.
+        /// </param>
+        /// <param name="condition">The additional condition to evaluate on a matching attribute.</param>
+        /// <typeparam name="TAttribute">The attribute type or marker interface to search for.</typeparam>
+        public TypeFilter HasAttribute<TAttribute>(bool inherited, Func<TAttribute, bool> condition)
+            where TAttribute : class
+        {
+            ArgumentNullException.ThrowIfNull(condition);
+            return filter.HasAttributes<TAttribute>(inherited, attributes => attributes.Any(condition));
+        }
+
+        /// <summary>
+        ///     Filters to types decorated with one or more attributes assignable to <paramref name="attributeType"/>
+        ///     whose set satisfies <paramref name="condition"/>, including inherited attributes.
+        /// </summary>
+        /// <param name="attributeType">The attribute type or marker interface to search for.</param>
+        /// <param name="condition">The additional condition to evaluate on the matching attributes, if any were found.</param>
+        public TypeFilter HasAttributes(Type attributeType, Func<IEnumerable<Attribute>, bool> condition)
+        {
+            return filter.HasAttributes(attributeType, inherited: true, condition);
+        }
+
+        /// <summary>
+        ///     Filters to types decorated with one or more attributes assignable to <typeparamref name="TAttribute"/>
+        ///     whose set satisfies <paramref name="condition"/>, including inherited attributes.
+        /// </summary>
+        /// <param name="condition">The additional condition to evaluate on the matching attributes, if any were found.</param>
+        /// <typeparam name="TAttribute">The attribute type or marker interface to search for.</typeparam>
+        public TypeFilter HasAttributes<TAttribute>(Func<IEnumerable<TAttribute>, bool> condition)
+            where TAttribute : class
+        {
+            return filter.HasAttributes(inherited: true, condition);
+        }
+
+        /// <summary>
+        ///     Filters to types decorated with one or more attributes assignable to <paramref name="attributeType"/>
+        ///     whose set satisfies <paramref name="condition"/>.
+        /// </summary>
+        /// <param name="attributeType">The attribute type or marker interface to search for.</param>
+        /// <param name="inherited">
+        ///     <see langword="true"/> to inspect the ancestors of the type; otherwise, <see langword="false"/>.
+        /// </param>
+        /// <param name="condition">The additional condition to evaluate on the matching attributes, if any were found.</param>
+        public TypeFilter HasAttributes(Type attributeType, bool inherited, Func<IEnumerable<Attribute>, bool> condition)
+        {
+            ValidateAttributeType(attributeType);
+            ArgumentNullException.ThrowIfNull(condition);
+            return filter.Where(type =>
+            {
+                var attributes = type.GetCustomAttributes(inherited)
+                    .Cast<Attribute>()
+                    .Where(attributeType.IsInstanceOfType)
+                    .ToArray();
+                return attributes.Length > 0 && condition(attributes);
+            });
+        }
+
+        /// <summary>
+        ///     Filters to types decorated with one or more attributes assignable to <typeparamref name="TAttribute"/>
+        ///     whose set satisfies <paramref name="condition"/>.
+        /// </summary>
+        /// <param name="inherited">
+        ///     <see langword="true"/> to inspect the ancestors of the type; otherwise, <see langword="false"/>.
+        /// </param>
+        /// <param name="condition">The additional condition to evaluate on the matching attributes, if any were found.</param>
+        /// <typeparam name="TAttribute">The attribute type or marker interface to search for.</typeparam>
+        public TypeFilter HasAttributes<TAttribute>(bool inherited, Func<IEnumerable<TAttribute>, bool> condition)
+            where TAttribute : class
+        {
+            ValidateAttributeType(typeof(TAttribute));
+            ArgumentNullException.ThrowIfNull(condition);
+            return filter.Where(type =>
+            {
+                var attributes = type.GetCustomAttributes(inherited).OfType<TAttribute>().ToArray();
+                return attributes.Length > 0 && condition(attributes);
+            });
+        }
+    }
+
+    /// <summary>
+    ///     Ensures a requested attribute type can actually match a custom attribute: it must be an attribute
+    ///     type or an interface an attribute could implement. Anything else (e.g. <see cref="string"/>) can
+    ///     never match, so it is rejected rather than silently filtering everything out.
+    /// </summary>
+    private static void ValidateAttributeType(Type attributeType)
+    {
+        ArgumentNullException.ThrowIfNull(attributeType);
+        if (
+            !attributeType.IsInterface
+            && !attributeType.IsSubclassOf(typeof(Attribute))
+            && attributeType != typeof(Attribute)
+        )
+        {
+            throw new ArgumentException(
+                $"'{attributeType}' must be an attribute type or an interface.",
+                nameof(attributeType)
+            );
+        }
+    }
+}

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/TypeFilterExtensions.BasedOn.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/TypeFilterExtensions.BasedOn.cs
@@ -1,5 +1,3 @@
-using System.Reflection;
-
 namespace ZCrew.Extensions.DependencyInjection.Registration;
 
 public static partial class TypeFilterExtensions

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesAttributeFilterTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesAttributeFilterTests.cs
@@ -1,0 +1,444 @@
+using Fixtures.SmallProject.Application.Caching;
+using Fixtures.SmallProject.Application.Services;
+using Fixtures.SmallProject.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests.ClassesTests;
+
+public class ClassesAttributeFilterTests
+{
+    [Fact]
+    public void HasAttribute_WithAttributeType_ShouldFilterToDecoratedTypes()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(RegionalCustomerStore), typeof(UnmarkedStore))
+            .HasAttribute(typeof(RegionCacheAttribute))
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(RegionalCustomerStore), registeredTypes);
+        Assert.DoesNotContain(typeof(UnmarkedStore), registeredTypes);
+    }
+
+    [Fact]
+    public void HasAttribute_WithGenericAttribute_ShouldFilterToDecoratedTypes()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(RegionalCustomerStore), typeof(UnmarkedStore))
+            .HasAttribute<RegionCacheAttribute>()
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(RegionalCustomerStore), registeredTypes);
+        Assert.DoesNotContain(typeof(UnmarkedStore), registeredTypes);
+    }
+
+    [Fact]
+    public void HasAttribute_WhenNoTypeHasAttribute_ShouldReturnEmpty()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(UnmarkedStore), typeof(RegionalCustomerStore))
+            .HasAttribute<TracedAttribute>()
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void HasAttribute_WithInheritedTrue_ShouldMatchDerivedType()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(TracedBase), typeof(TracedDerived))
+            .HasAttribute(typeof(TracedAttribute), inherited: true)
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(TracedBase), registeredTypes);
+        Assert.Contains(typeof(TracedDerived), registeredTypes);
+    }
+
+    [Fact]
+    public void HasAttribute_WithInheritedFalse_ShouldMatchOnlyDeclaringType()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(TracedBase), typeof(TracedDerived))
+            .HasAttribute(typeof(TracedAttribute), inherited: false)
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(TracedBase), registeredTypes);
+        Assert.DoesNotContain(typeof(TracedDerived), registeredTypes);
+    }
+
+    [Fact]
+    public void HasAttribute_WithGenericInheritedTrue_ShouldMatchDerivedType()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(TracedBase), typeof(TracedDerived))
+            .HasAttribute<TracedAttribute>(inherited: true)
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(TracedBase), registeredTypes);
+        Assert.Contains(typeof(TracedDerived), registeredTypes);
+    }
+
+    [Fact]
+    public void HasAttribute_WithNonInheritedAttributeAndInheritedTrue_ShouldNotMatchDerivedType()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(LocalOnlyBase), typeof(LocalOnlyDerived))
+            .HasAttribute<LocalOnlyAttribute>(inherited: true)
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(LocalOnlyBase), registeredTypes);
+        Assert.DoesNotContain(typeof(LocalOnlyDerived), registeredTypes);
+    }
+
+    [Fact]
+    public void HasAttribute_WithAttributeTypeAndCondition_ShouldFilterByAttributeValue()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(RegionalCustomerStore), typeof(RegionalOrderStore))
+            .HasAttribute(typeof(RegionCacheAttribute), a => ((RegionCacheAttribute)a).Region == "customers")
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(RegionalCustomerStore), registeredTypes);
+        Assert.DoesNotContain(typeof(RegionalOrderStore), registeredTypes);
+    }
+
+    [Fact]
+    public void HasAttribute_WithGenericCondition_ShouldFilterByAttributeValue()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(RegionalCustomerStore), typeof(RegionalOrderStore))
+            .HasAttribute<RegionCacheAttribute>(a => a.Region == "customers")
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(RegionalCustomerStore), registeredTypes);
+        Assert.DoesNotContain(typeof(RegionalOrderStore), registeredTypes);
+    }
+
+    [Fact]
+    public void HasAttribute_WithConditionAndTypeMissingAttribute_ShouldExcludeType()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(RegionalCustomerStore), typeof(UnmarkedStore))
+            .HasAttribute<RegionCacheAttribute>(a => a.Region.Length > 0)
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(RegionalCustomerStore), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void HasAttribute_WithConditionAndInheritedTrue_ShouldMatchDerivedType()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(TracedBase), typeof(TracedDerived))
+            .HasAttribute(typeof(TracedAttribute), inherited: true, a => ((TracedAttribute)a).Channel == "audit")
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(TracedBase), registeredTypes);
+        Assert.Contains(typeof(TracedDerived), registeredTypes);
+    }
+
+    [Fact]
+    public void HasAttribute_WithGenericConditionAndInheritedFalse_ShouldNotMatchDerivedType()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(TracedBase), typeof(TracedDerived))
+            .HasAttribute<TracedAttribute>(inherited: false, a => a.Channel == "audit")
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(TracedBase), registeredTypes);
+        Assert.DoesNotContain(typeof(TracedDerived), registeredTypes);
+    }
+
+    [Fact]
+    public void HasAttributes_WithCondition_ShouldFilterByAttributeCount()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(MultiTagged), typeof(SingleTagged))
+            .HasAttributes(typeof(TagAttribute), attributes => attributes.Count() >= 2)
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(MultiTagged), registeredTypes);
+        Assert.DoesNotContain(typeof(SingleTagged), registeredTypes);
+    }
+
+    [Fact]
+    public void HasAttributes_WithGenericCondition_ShouldFilterByAttributeCount()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(MultiTagged), typeof(SingleTagged))
+            .HasAttributes<TagAttribute>(attributes => attributes.Count() >= 2)
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(MultiTagged), registeredTypes);
+        Assert.DoesNotContain(typeof(SingleTagged), registeredTypes);
+    }
+
+    [Fact]
+    public void HasAttributes_WithConditionRequiringAll_ShouldFilterByEveryAttribute()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(MultiTagged), typeof(SingleTagged))
+            .HasAttributes<TagAttribute>(attributes => attributes.All(t => t.Name.Length == 1))
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(MultiTagged), registeredTypes);
+        Assert.DoesNotContain(typeof(SingleTagged), registeredTypes);
+    }
+
+    [Fact]
+    public void HasAttributes_WithConditionAndInheritedTrue_ShouldMatchDerivedType()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(TaggedDerived))
+            .HasAttributes(typeof(TagAttribute), inherited: true, attributes => attributes.Count() >= 2)
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(TaggedDerived), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void HasAttributes_WithGenericConditionAndInheritedFalse_ShouldNotMatchDerivedType()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(TaggedDerived))
+            .HasAttributes<TagAttribute>(inherited: false, attributes => attributes.Count() >= 2)
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void HasAttribute_WithMarkerInterfaceType_ShouldMatchAllImplementingAttributes()
+    {
+        // Act
+        var result = Classes
+            .From(
+                typeof(RegionalCustomerStore),
+                typeof(RegionalOrderStore),
+                typeof(PartitionedPaymentStore),
+                typeof(UnmarkedStore)
+            )
+            .HasAttribute(typeof(IRegionAware))
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Equal(3, registeredTypes.Length);
+        Assert.Contains(typeof(RegionalCustomerStore), registeredTypes);
+        Assert.Contains(typeof(RegionalOrderStore), registeredTypes);
+        Assert.Contains(typeof(PartitionedPaymentStore), registeredTypes);
+    }
+
+    [Fact]
+    public void HasAttribute_WithMarkerInterfaceGeneric_ShouldMatchAllImplementingAttributes()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(RegionalCustomerStore), typeof(PartitionedPaymentStore), typeof(UnmarkedStore))
+            .HasAttribute<IRegionAware>()
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(RegionalCustomerStore), registeredTypes);
+        Assert.Contains(typeof(PartitionedPaymentStore), registeredTypes);
+        Assert.DoesNotContain(typeof(UnmarkedStore), registeredTypes);
+    }
+
+    [Fact]
+    public void HasAttribute_WithMarkerInterfaceCondition_ShouldFilterByInterfaceProperty()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(RegionalCustomerStore), typeof(RegionalOrderStore), typeof(PartitionedPaymentStore))
+            .HasAttribute<IRegionAware>(a => a.Region == "customers")
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(RegionalCustomerStore), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void HasAttribute_WithNonAttributeType_ShouldThrowArgumentException()
+    {
+        // Arrange
+        var filter = Classes.From(typeof(RegionalCustomerStore));
+
+        // Act
+        var act = () => filter.HasAttribute(typeof(string));
+
+        // Assert
+        Assert.Throws<ArgumentException>(act);
+    }
+
+    [Fact]
+    public void HasAttribute_WithNonAttributeGenericType_ShouldThrowArgumentException()
+    {
+        // Arrange
+        var filter = Classes.From(typeof(RegionalCustomerStore));
+
+        // Act
+        var act = () => filter.HasAttribute<object>();
+
+        // Assert
+        Assert.Throws<ArgumentException>(act);
+    }
+
+    [Fact]
+    public void HasAttribute_WithNullAttributeType_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        var filter = Classes.From(typeof(RegionalCustomerStore));
+
+        // Act
+        var act = () => filter.HasAttribute(null!);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(act);
+    }
+
+    [Fact]
+    public void HasAttribute_WithNullCondition_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        var filter = Classes.From(typeof(RegionalCustomerStore));
+
+        // Act
+        var act = () => filter.HasAttribute<RegionCacheAttribute>(null!);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(act);
+    }
+
+    [Fact]
+    public void HasAttributes_WithNullCondition_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        var filter = Classes.From(typeof(MultiTagged));
+
+        // Act
+        var act = () => filter.HasAttributes<TagAttribute>(null!);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(act);
+    }
+
+    [Fact]
+    public void HasAttribute_WhenCombinedWithWhere_ShouldApplyBoth()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(RegionalCustomerStore), typeof(RegionalOrderStore), typeof(PartitionedPaymentStore))
+            .Where(t => t.Name.Contains("Customer"))
+            .HasAttribute<IRegionAware>()
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(RegionalCustomerStore), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void HasAttribute_WhenCombinedWithBasedOn_ShouldApplyBoth()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(CustomerService), typeof(CachingCustomerService))
+            .BasedOn<ICustomerService>()
+            .HasAttribute<CacheableAttribute>()
+            .AsBase()
+            .ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(CachingCustomerService), descriptor.ImplementationType);
+        Assert.Equal(typeof(ICustomerService), descriptor.ServiceType);
+    }
+
+    [Fact]
+    public void HasAttribute_WhenEnumeratedWithoutTerminalMethod_ShouldDefaultToSelfRegistration()
+    {
+        // Arrange
+        var filter = Classes.From(typeof(RegionalCustomerStore), typeof(UnmarkedStore)).HasAttribute<RegionCacheAttribute>();
+
+        // Act
+        var result = filter.ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(RegionalCustomerStore), descriptor.ServiceType);
+        Assert.Equal(typeof(RegionalCustomerStore), descriptor.ImplementationType);
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+    }
+}

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesAttributeFilterTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesAttributeFilterTests.cs
@@ -1,0 +1,87 @@
+using Fixtures.SmallProject.Attributes;
+
+namespace ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests.TypesTests;
+
+public class TypesAttributeFilterTests
+{
+    [Fact]
+    public void HasAttribute_WithDecoratedInterface_ShouldMatch()
+    {
+        // Act
+        var result = Types
+            .From(typeof(IMarkedContract), typeof(MarkedClass), typeof(UnmarkedStore))
+            .HasAttribute<MetaAttribute>()
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(IMarkedContract), registeredTypes);
+        Assert.Contains(typeof(MarkedClass), registeredTypes);
+        Assert.DoesNotContain(typeof(UnmarkedStore), registeredTypes);
+    }
+
+    [Fact]
+    public void HasAttribute_WithDecoratedStruct_ShouldMatch()
+    {
+        // Act
+        var result = Types
+            .From(typeof(MarkedValue), typeof(UnmarkedStore))
+            .HasAttribute<MetaAttribute>()
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(MarkedValue), registeredTypes);
+        Assert.DoesNotContain(typeof(UnmarkedStore), registeredTypes);
+    }
+
+    [Fact]
+    public void HasAttribute_WithDecoratedEnum_ShouldMatch()
+    {
+        // Act
+        var result = Types
+            .From(typeof(MarkedEnum), typeof(UnmarkedStore))
+            .HasAttribute<MetaAttribute>()
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(MarkedEnum), registeredTypes);
+        Assert.DoesNotContain(typeof(UnmarkedStore), registeredTypes);
+    }
+
+    [Fact]
+    public void HasAttribute_WithClassesEntry_ShouldExcludeNonClassKinds()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(IMarkedContract), typeof(MarkedValue), typeof(MarkedEnum), typeof(MarkedClass))
+            .HasAttribute<MetaAttribute>()
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(MarkedClass), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void HasAttribute_WithMarkerInterfaceThroughTypes_ShouldMatchImplementingAttributes()
+    {
+        // Act
+        var result = Types
+            .From(typeof(RegionalCustomerStore), typeof(PartitionedPaymentStore), typeof(UnmarkedStore))
+            .HasAttribute(typeof(IRegionAware))
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(RegionalCustomerStore), registeredTypes);
+        Assert.Contains(typeof(PartitionedPaymentStore), registeredTypes);
+        Assert.DoesNotContain(typeof(UnmarkedStore), registeredTypes);
+    }
+}

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.UnitTests/ChainLazinessTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.UnitTests/ChainLazinessTests.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using Fixtures.SmallProject.Application.Services;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace ZCrew.Extensions.DependencyInjection.Registration.UnitTests;
 
@@ -50,6 +49,19 @@ public class ChainLazinessTests
     {
         // Arrange
         var chain = Types.From(new ThrowingTypeSequence()).Where(_ => true).AsSelf();
+
+        // Act
+        var terminate = () => chain.ToServiceCollection();
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(terminate);
+    }
+
+    [Fact]
+    public void HasAttribute_WhenChainBuilt_ShouldNotEnumerateUntilTerminated()
+    {
+        // Arrange
+        var chain = Types.From(new ThrowingTypeSequence()).HasAttribute<ObsoleteAttribute>().AsSelf();
 
         // Act
         var terminate = () => chain.ToServiceCollection();


### PR DESCRIPTION
Adds `HasAttribute` and `HasAttributes` types. This can be used to filter based on attributes, supplying a delegate to evaluate the attributes.

Closes #42