### PR TITLE
#46 - Add in 'OrSelf' fallback to interface selection

### DIFF
--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceSelectorExtensions.Interfaces.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceSelectorExtensions.Interfaces.cs
@@ -21,6 +21,27 @@ public static partial class ServiceSelectorExtensions
         }
 
         /// <summary>
+        ///     Registers each type against all interfaces it implements; or <see cref="AsSelf"/> if there were no
+        ///     interfaces found.
+        /// </summary>
+        /// <example>
+        ///     Given <c>CustomerRepository : ICustomerRepository, IDisposable</c>:
+        ///     <code>
+        ///     Classes.From(types).AsAllInterfacesOrSelf()
+        ///     // Registers CustomerRepository as both
+        ///     // ICustomerRepository and IDisposable
+        ///     </code>
+        /// </example>
+        public ServiceKeySelector AsAllInterfacesOrSelf()
+        {
+            return selector.As(type =>
+            {
+                var interfaces = type.GetInterfaces();
+                return interfaces.Length == 0 ? [type] : interfaces;
+            });
+        }
+
+        /// <summary>
         ///     Registers each type against all interfaces it implements, excluding interfaces in the <c>System</c>
         ///     namespace and its sub-namespaces.
         /// </summary>
@@ -37,6 +58,28 @@ public static partial class ServiceSelectorExtensions
             return selector.As(type =>
                 type.GetInterfaces().Where(service => !service.IsInSameNamespaceAs<object>(includeSubnamespaces: true))
             );
+        }
+
+        /// <summary>
+        ///     Registers each type against all interfaces it implements, excluding interfaces in the <c>System</c>
+        ///     namespace and its sub-namespaces; or <see cref="AsSelf"/> if there were no interfaces found.
+        /// </summary>
+        /// <example>
+        ///     Given <c>CustomerRepository : ICustomerRepository, IDisposable</c>:
+        ///     <code>
+        ///     Classes.From(types).AsAllNonSystemInterfacesOrSelf()
+        ///     // Registers CustomerRepository as ICustomerRepository only
+        ///     // (IDisposable is in System and is excluded)
+        ///     </code>
+        /// </example>
+        public ServiceKeySelector AsAllNonSystemInterfacesOrSelf()
+        {
+            return selector.As(type =>
+            {
+                var interfaces = type.GetInterfaces().Where(service =>
+                    !service.IsInSameNamespaceAs<object>(includeSubnamespaces: true)).ToArray();
+                return interfaces.Length == 0 ? [type] : interfaces;
+            });
         }
 
         /// <summary>
@@ -59,6 +102,28 @@ public static partial class ServiceSelectorExtensions
         }
 
         /// <summary>
+        ///     Registers each type against interfaces whose name matches the type name by convention; or
+        ///     <see cref="AsSelf"/> if there were no interfaces found.
+        /// </summary>
+        /// <example>
+        ///     Given <c>CustomerRepository : ICustomerRepository, IDisposable</c>:
+        ///     <code>
+        ///     Classes.From(types).AsDefaultInterfacesOrSelf()
+        ///     // Registers CustomerRepository as ICustomerRepository
+        ///     // ("CustomerRepository" contains "CustomerRepository" from
+        ///     // "ICustomerRepository", but not "Disposable")
+        ///     </code>
+        /// </example>
+        public ServiceKeySelector AsDefaultInterfacesOrSelf()
+        {
+            return selector.As(type =>
+            {
+                var interfaces = type.GetInterfaces().Where(service => type.Name.Contains(service.GetInterfaceName())).ToArray();
+                return interfaces.Length == 0 ? [type] : interfaces;
+            });
+        }
+
+        /// <summary>
         ///     Registers each type against convention-matching interfaces (see <see cref="AsDefaultInterfaces"/>),
         ///     additionally excluding interfaces in the <c>System</c> namespace and its sub-namespaces.
         /// </summary>
@@ -74,6 +139,28 @@ public static partial class ServiceSelectorExtensions
                     .Where(service => type.Name.Contains(service.GetInterfaceName()))
                     .Where(service => !service.IsInSameNamespaceAs<object>(includeSubnamespaces: true))
             );
+        }
+
+        /// <summary>
+        ///     Registers each type against convention-matching interfaces (see <see cref="AsDefaultInterfaces"/>),
+        ///     additionally excluding interfaces in the <c>System</c> namespace and its sub-namespaces; or
+        ///     <see cref="AsSelf"/> if there were no interfaces found.
+        /// </summary>
+        /// <example>
+        ///     <code>
+        ///     Classes.From(types).AsDefaultNonSystemInterfacesOrSelf()
+        ///     </code>
+        /// </example>
+        public ServiceKeySelector AsDefaultNonSystemInterfacesOrSelf()
+        {
+            return selector.As(type =>
+            {
+                var interfaces = type.GetInterfaces()
+                    .Where(service => type.Name.Contains(service.GetInterfaceName()))
+                    .Where(service => !service.IsInSameNamespaceAs<object>(includeSubnamespaces: true))
+                    .ToArray();
+                return interfaces.Length == 0 ? [type] : interfaces;
+            });
         }
 
         /// <summary>
@@ -97,6 +184,23 @@ public static partial class ServiceSelectorExtensions
         }
 
         /// <summary>
+        ///     Registers each type against the first interface it implements; or <see cref="AsSelf"/> if there were no
+        ///     interfaces found.
+        /// </summary>
+        /// <example>
+        ///     Given <c>Order : object</c> and <c>CustomerRepository : ICustomerRepository, IRepository</c>:
+        ///     <code>
+        ///     Classes.From(types).AsFirstInterface()
+        ///     // Registers Order as Order
+        ///     //           CustomerRepository as ICustomerRepository
+        ///     </code>
+        /// </example>
+        public ServiceKeySelector AsFirstInterfaceOrSelf()
+        {
+            return selector.As(type => [type.GetInterfaces().FirstOrDefault(type)]);
+        }
+
+        /// <summary>
         ///     Registers each type against its top-level interfaces that derive from the base types specified via
         ///     <see cref="TypeFilter.BasedOn"/>.
         /// </summary>
@@ -115,6 +219,30 @@ public static partial class ServiceSelectorExtensions
         }
 
         /// <summary>
+        ///     Registers each type against its top-level interfaces that derive from the base types specified via
+        ///     <see cref="TypeFilter.BasedOn"/>; or <see cref="AsSelf"/> if there were no interfaces found.
+        /// </summary>
+        /// <example>
+        ///     Given <c>Order : object</c> and <c>CustomerRepository : ICustomerRepository : IRepository</c>:
+        ///     <code>
+        ///     Classes.From(types)
+        ///         .BasedOn&lt;IRepository&gt;()
+        ///         .AsInterface()
+        ///     // Registers Order as Order
+        ///     //           CustomerRepository as ICustomerRepository
+        ///     </code>
+        ///     Types without an interface are registered as themselves.
+        /// </example>
+        public ServiceKeySelector AsInterfaceOrSelf()
+        {
+            return selector.As((type, baseTypes) =>
+            {
+                var interfaces = type.GetTopLevelInterfacesMatchingBaseTypes(baseTypes).ToArray();
+                return interfaces.Length == 0 ? [type] : interfaces;
+            });
+        }
+
+        /// <summary>
         ///     Registers each type against its top-level interfaces that derive from <typeparamref name="T"/>.
         /// </summary>
         /// <typeparam name="T">The base interface type to match against.</typeparam>
@@ -128,6 +256,29 @@ public static partial class ServiceSelectorExtensions
         public ServiceKeySelector AsInterface<T>()
         {
             return selector.As(type => type.GetTopLevelInterfacesMatchingBaseTypes([typeof(T)]));
+        }
+
+        /// <summary>
+        ///     Registers each type against its top-level interfaces that derive from <typeparamref name="T"/>; or
+        ///     <see cref="AsSelf"/> if there were no interfaces found.
+        /// </summary>
+        /// <typeparam name="T">The base interface type to match against.</typeparam>
+        /// <example>
+        ///     Given <c>Order : object</c> and <c>CustomerRepository : ICustomerRepository : IRepository</c>:
+        ///     <code>
+        ///     Classes.From(types).AsInterface&lt;IRepository&gt;()
+        ///     // Registers Order as Order
+        ///     //           CustomerRepository as ICustomerRepository
+        ///     </code>
+        ///     Types without an interface are registered as themselves.
+        /// </example>
+        public ServiceKeySelector AsInterfaceOrSelf<T>()
+        {
+            return selector.As(type =>
+            {
+                var interfaces = type.GetTopLevelInterfacesMatchingBaseTypes([typeof(T)]).ToArray();
+                return interfaces.Length == 0 ? [type] : interfaces;
+            });
         }
 
         /// <summary>
@@ -148,6 +299,30 @@ public static partial class ServiceSelectorExtensions
         }
 
         /// <summary>
+        ///     Registers each type against its top-level interfaces that derive from <paramref name="interfaceType"/>;
+        ///     or <see cref="AsSelf"/> if there were no interfaces found.
+        /// </summary>
+        /// <param name="interfaceType">The base interface type to match against.</param>
+        /// <example>
+        ///     Given <c>Order : object</c> and <c>CustomerRepository : ICustomerRepository : IRepository</c>:
+        ///     <code>
+        ///     Classes.From(types).AsInterface(typeof(IRepository))
+        ///     // Registers Order as Order
+        ///     //           CustomerRepository as ICustomerRepository
+        ///     </code>
+        ///     Types without an interface are registered as themselves.
+        /// </example>
+        public ServiceKeySelector AsInterfaceOrSelf(Type interfaceType)
+        {
+            ArgumentNullException.ThrowIfNull(interfaceType);
+            return selector.As(type =>
+            {
+                var interfaces = type.GetTopLevelInterfacesMatchingBaseTypes([interfaceType]).ToArray();
+                return interfaces.Length == 0 ? [type] : interfaces;
+            });
+        }
+
+        /// <summary>
         ///     Registers each type against its top-level interfaces that derive from any of the specified
         ///     <paramref name="interfaceTypes"/>.
         /// </summary>
@@ -159,7 +334,7 @@ public static partial class ServiceSelectorExtensions
         ///     Classes.From(types)
         ///         .AsInterfaces(typeof(IService), typeof(IRepository))
         ///     // Registers OrderService as IOrderService,
-        ///     //          OrderRepository as IOrderRepository
+        ///     //           OrderRepository as IOrderRepository
         ///     </code>
         /// </example>
         public ServiceKeySelector AsInterfaces(params Type[] interfaceTypes)
@@ -167,6 +342,34 @@ public static partial class ServiceSelectorExtensions
             ArgumentNullException.ThrowIfNull(selector);
             ArgumentNullException.ThrowIfNull(interfaceTypes);
             return selector.As(type => type.GetTopLevelInterfacesMatchingBaseTypes(interfaceTypes));
+        }
+
+        /// <summary>
+        ///     Registers each type against its top-level interfaces that derive from any of the specified
+        ///     <paramref name="interfaceTypes"/>; or <see cref="AsSelf"/> if there were no interfaces found.
+        /// </summary>
+        /// <param name="interfaceTypes">The base interface types to match against.</param>
+        /// <example>
+        ///     Given <c>Order : object</c>, <c>OrderService : IOrderService : IService</c> and
+        ///     <c>OrderRepository : IOrderRepository : IRepository</c>:
+        ///     <code>
+        ///     Classes.From(types)
+        ///         .AsInterfaces(typeof(IService), typeof(IRepository))
+        ///     // Registers Order as Order
+        ///     //           OrderService as IOrderService,
+        ///     //           OrderRepository as IOrderRepository
+        ///     </code>
+        ///     Types without an interface are registered as themselves.
+        /// </example>
+        public ServiceKeySelector AsInterfacesOrSelf(params Type[] interfaceTypes)
+        {
+            ArgumentNullException.ThrowIfNull(selector);
+            ArgumentNullException.ThrowIfNull(interfaceTypes);
+            return selector.As(type =>
+            {
+                var interfaces = type.GetTopLevelInterfacesMatchingBaseTypes(interfaceTypes).ToArray();
+                return interfaces.Length == 0 ? [type] : interfaces;
+            });
         }
     }
 }

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesServiceSelectionTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesServiceSelectionTests.cs
@@ -3,6 +3,7 @@ using Fixtures.SmallProject.Application.Ports;
 using Fixtures.SmallProject.Application.Services;
 using Fixtures.SmallProject.Domain.Entities;
 using Fixtures.SmallProject.Domain.Repositories;
+using Fixtures.SmallProject.Domain.ValueObjects;
 using Fixtures.SmallProject.Infrastructure.External;
 using Fixtures.SmallProject.Infrastructure.Notifications;
 using Fixtures.SmallProject.Infrastructure.Persistence;
@@ -452,5 +453,347 @@ public class ClassesServiceSelectionTests
         var descriptor = Assert.Single(result);
         Assert.Equal(typeof(OrderValidationStep), descriptor.ImplementationType);
         Assert.Equal(typeof(Pipeline<Order>.IStep), descriptor.ServiceType);
+    }
+
+    [Fact]
+    public void AsAllInterfacesOrSelf_WhenInterfacesExist_ShouldRegisterAllInterfaces()
+    {
+        // Act
+        var result = Classes.From(typeof(PayPalPaymentGateway)).AsAllInterfacesOrSelf().ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(IPaymentGateway), serviceTypes);
+        Assert.Contains(typeof(IDisposable), serviceTypes);
+    }
+
+    [Fact]
+    public void AsAllInterfacesOrSelf_WhenNoInterfaces_ShouldRegisterSelf()
+    {
+        // Act
+        var result = Classes.From(typeof(Customer)).AsAllInterfacesOrSelf().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(Customer), descriptor.ServiceType);
+        Assert.Equal(typeof(Customer), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void AsAllNonSystemInterfacesOrSelf_WhenNonSystemInterfacesExist_ShouldRegisterNonSystemInterfaces()
+    {
+        // Act
+        var result = Classes.From(typeof(PayPalPaymentGateway)).AsAllNonSystemInterfacesOrSelf().ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(IPaymentGateway), serviceTypes);
+        Assert.DoesNotContain(typeof(IDisposable), serviceTypes);
+        Assert.DoesNotContain(typeof(PayPalPaymentGateway), serviceTypes);
+    }
+
+    [Fact]
+    public void AsAllNonSystemInterfacesOrSelf_WhenOnlySystemInterfaces_ShouldRegisterSelf()
+    {
+        // Act
+        var result = Classes.From(typeof(Address)).AsAllNonSystemInterfacesOrSelf().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(Address), descriptor.ServiceType);
+        Assert.Equal(typeof(Address), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void AsDefaultInterfacesOrSelf_WhenConventionMatches_ShouldRegisterMatchingInterface()
+    {
+        // Act
+        var result = Classes.From(typeof(CustomerService)).AsDefaultInterfacesOrSelf().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(CustomerService), descriptor.ImplementationType);
+        Assert.Equal(typeof(ICustomerService), descriptor.ServiceType);
+    }
+
+    [Fact]
+    public void AsDefaultInterfacesOrSelf_WhenNoConventionMatch_ShouldRegisterSelf()
+    {
+        // Act
+        var result = Classes.From(typeof(LegacyOrderProcessor)).AsDefaultInterfacesOrSelf().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(LegacyOrderProcessor), descriptor.ServiceType);
+        Assert.Equal(typeof(LegacyOrderProcessor), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void AsDefaultNonSystemInterfacesOrSelf_WhenConventionMatchesNonSystem_ShouldRegisterMatchingInterface()
+    {
+        // Act
+        var result = Classes.From(typeof(CustomerService)).AsDefaultNonSystemInterfacesOrSelf().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(CustomerService), descriptor.ImplementationType);
+        Assert.Equal(typeof(ICustomerService), descriptor.ServiceType);
+    }
+
+    [Fact]
+    public void AsDefaultNonSystemInterfacesOrSelf_WhenNoMatch_ShouldRegisterSelf()
+    {
+        // Act
+        var result = Classes.From(typeof(Address)).AsDefaultNonSystemInterfacesOrSelf().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(Address), descriptor.ServiceType);
+        Assert.Equal(typeof(Address), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void AsFirstInterfaceOrSelf_WhenInterfacesExist_ShouldRegisterFirstInterface()
+    {
+        // Act
+        var result = Classes.From(typeof(CustomerService)).AsFirstInterfaceOrSelf().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(CustomerService), descriptor.ImplementationType);
+        Assert.Contains(descriptor.ServiceType, typeof(CustomerService).GetInterfaces());
+    }
+
+    [Fact]
+    public void AsFirstInterfaceOrSelf_WhenNoInterfaces_ShouldRegisterSelf()
+    {
+        // Act
+        var result = Classes.From(typeof(Customer)).AsFirstInterfaceOrSelf().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(Customer), descriptor.ServiceType);
+        Assert.Equal(typeof(Customer), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void AsInterfaceOrSelf_WithBasedOn_ShouldRegisterTopLevelDerivedInterface()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(SqlCustomerRepository))
+            .BasedOn(typeof(IRepository<>))
+            .AsInterfaceOrSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(SqlCustomerRepository), descriptor.ImplementationType);
+        Assert.Equal(typeof(ICustomerRepository), descriptor.ServiceType);
+    }
+
+    [Fact]
+    public void AsInterfaceOrSelf_WhenNoMatchingInterface_ShouldRegisterSelf()
+    {
+        // Act
+        var result = Classes.From(typeof(Customer)).AsInterfaceOrSelf().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(Customer), descriptor.ServiceType);
+        Assert.Equal(typeof(Customer), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void AsInterfaceOrSelf_T_WhenMatchingInterface_ShouldRegisterInterface()
+    {
+        // Act
+        var result = Classes.From(typeof(CustomerService)).AsInterfaceOrSelf<ICustomerService>().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(CustomerService), descriptor.ImplementationType);
+        Assert.Equal(typeof(ICustomerService), descriptor.ServiceType);
+    }
+
+    [Fact]
+    public void AsInterfaceOrSelf_T_WhenTypeHasNoMatchingInterface_ShouldRegisterSelf()
+    {
+        // Act
+        var result = Classes.From(typeof(CustomerService)).AsInterfaceOrSelf<IPaymentGateway>().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(CustomerService), descriptor.ServiceType);
+        Assert.Equal(typeof(CustomerService), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void AsInterfaceOrSelf_WithExplicitType_WhenMatching_ShouldRegisterInterface()
+    {
+        // Act
+        var result = Classes.From(typeof(CustomerService)).AsInterfaceOrSelf(typeof(ICustomerService)).ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(CustomerService), descriptor.ImplementationType);
+        Assert.Equal(typeof(ICustomerService), descriptor.ServiceType);
+    }
+
+    [Fact]
+    public void AsInterfaceOrSelf_WithExplicitType_WhenNoMatch_ShouldRegisterSelf()
+    {
+        // Act
+        var result = Classes.From(typeof(CustomerService)).AsInterfaceOrSelf(typeof(IPaymentGateway)).ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(CustomerService), descriptor.ServiceType);
+        Assert.Equal(typeof(CustomerService), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void AsInterfaceOrSelf_WithExplicitType_WhenTypeIsNull_ShouldThrow()
+    {
+        // Act
+        var act = () => Classes.From(typeof(Customer)).AsInterfaceOrSelf((Type)null!);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(act);
+    }
+
+    [Fact]
+    public void AsInterfacesOrSelf_WithMultipleBaseTypes_ShouldRegisterDerivedInterfaces()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(CustomerService), typeof(OrderService))
+            .AsInterfacesOrSelf(typeof(ICustomerService), typeof(IOrderService))
+            .ToServiceCollection();
+
+        // Assert
+        Assert.Contains(
+            result,
+            d => d.ImplementationType == typeof(CustomerService) && d.ServiceType == typeof(ICustomerService)
+        );
+        Assert.Contains(
+            result,
+            d => d.ImplementationType == typeof(OrderService) && d.ServiceType == typeof(IOrderService)
+        );
+    }
+
+    [Fact]
+    public void AsInterfacesOrSelf_WhenNoMatchingInterface_ShouldRegisterSelf()
+    {
+        // Act
+        var result = Classes.From(typeof(Customer)).AsInterfacesOrSelf(typeof(ICustomerService)).ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(Customer), descriptor.ServiceType);
+        Assert.Equal(typeof(Customer), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void AsInterfacesOrSelf_WhenInterfaceTypesIsNull_ShouldThrow()
+    {
+        // Act
+        var act = () => Classes.From(typeof(Customer)).AsInterfacesOrSelf((Type[])null!);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(act);
+    }
+
+    [Fact]
+    public void AsInterfaceOrSelf_WithMixedTypes_ShouldRegisterInterfacesAndSelfPerType()
+    {
+        // Act
+        var result = Classes.From(typeof(CustomerService), typeof(Customer)).AsInterfaceOrSelf().ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(ICustomerService), serviceTypes);
+        Assert.Contains(typeof(Customer), serviceTypes);
+        Assert.DoesNotContain(typeof(CustomerService), serviceTypes);
+    }
+
+    [Fact]
+    public void AsAllInterfaces_WhenNoInterfaces_ShouldNotRegister()
+    {
+        // Act
+        var result = Classes.From(typeof(Customer)).AsAllInterfaces().ToServiceCollection();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AsAllNonSystemInterfaces_WhenNoInterfaces_ShouldNotRegister()
+    {
+        // Act
+        var result = Classes.From(typeof(Customer)).AsAllNonSystemInterfaces().ToServiceCollection();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AsAllNonSystemInterfaces_WhenOnlySystemInterfaces_ShouldNotRegister()
+    {
+        // Act
+        var result = Classes.From(typeof(Address)).AsAllNonSystemInterfaces().ToServiceCollection();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AsDefaultNonSystemInterfaces_WhenNoMatch_ShouldNotRegister()
+    {
+        // Act
+        var result = Classes.From(typeof(LegacyOrderProcessor)).AsDefaultNonSystemInterfaces().ToServiceCollection();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AsInterface_WhenNoMatchingInterface_ShouldNotRegister()
+    {
+        // Act
+        var result = Classes.From(typeof(Customer)).AsInterface().ToServiceCollection();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AsInterface_WithExplicitType_WhenNoMatch_ShouldNotRegister()
+    {
+        // Act
+        var result = Classes.From(typeof(CustomerService)).AsInterface(typeof(IPaymentGateway)).ToServiceCollection();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AsInterfaces_WhenNoMatchingInterface_ShouldNotRegister()
+    {
+        // Act
+        var result = Classes.From(typeof(Customer)).AsInterfaces(typeof(ICustomerService)).ToServiceCollection();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AsInterfaces_WhenInterfaceTypesIsNull_ShouldThrow()
+    {
+        // Act
+        var act = () => Classes.From(typeof(Customer)).AsInterfaces((Type[])null!);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(act);
     }
 }

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesServiceSelectionTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesServiceSelectionTests.cs
@@ -3,6 +3,7 @@ using Fixtures.SmallProject.Application.Services;
 using Fixtures.SmallProject.Domain.Entities;
 using Fixtures.SmallProject.Domain.Repositories;
 using Fixtures.SmallProject.Domain.Services;
+using Fixtures.SmallProject.Domain.ValueObjects;
 using Fixtures.SmallProject.Infrastructure.External;
 using Fixtures.SmallProject.Infrastructure.Notifications;
 using Fixtures.SmallProject.Infrastructure.Persistence;
@@ -422,5 +423,347 @@ public class TypesServiceSelectionTests
         var descriptor = Assert.Single(result);
         Assert.Equal(typeof(SqlCustomerRepository), descriptor.ImplementationType);
         Assert.Equal(typeof(ICustomerRepository), descriptor.ServiceType);
+    }
+
+    [Fact]
+    public void AsAllInterfacesOrSelf_WhenInterfacesExist_ShouldRegisterAllInterfaces()
+    {
+        // Act
+        var result = Types.From(typeof(PayPalPaymentGateway)).AsAllInterfacesOrSelf().ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(IPaymentGateway), serviceTypes);
+        Assert.Contains(typeof(IDisposable), serviceTypes);
+    }
+
+    [Fact]
+    public void AsAllInterfacesOrSelf_WhenNoInterfaces_ShouldRegisterSelf()
+    {
+        // Act
+        var result = Types.From(typeof(Customer)).AsAllInterfacesOrSelf().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(Customer), descriptor.ServiceType);
+        Assert.Equal(typeof(Customer), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void AsAllNonSystemInterfacesOrSelf_WhenNonSystemInterfacesExist_ShouldRegisterNonSystemInterfaces()
+    {
+        // Act
+        var result = Types.From(typeof(PayPalPaymentGateway)).AsAllNonSystemInterfacesOrSelf().ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(IPaymentGateway), serviceTypes);
+        Assert.DoesNotContain(typeof(IDisposable), serviceTypes);
+        Assert.DoesNotContain(typeof(PayPalPaymentGateway), serviceTypes);
+    }
+
+    [Fact]
+    public void AsAllNonSystemInterfacesOrSelf_WhenOnlySystemInterfaces_ShouldRegisterSelf()
+    {
+        // Act
+        var result = Types.From(typeof(Address)).AsAllNonSystemInterfacesOrSelf().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(Address), descriptor.ServiceType);
+        Assert.Equal(typeof(Address), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void AsDefaultInterfacesOrSelf_WhenConventionMatches_ShouldRegisterMatchingInterface()
+    {
+        // Act
+        var result = Types.From(typeof(CustomerService)).AsDefaultInterfacesOrSelf().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(CustomerService), descriptor.ImplementationType);
+        Assert.Equal(typeof(ICustomerService), descriptor.ServiceType);
+    }
+
+    [Fact]
+    public void AsDefaultInterfacesOrSelf_WhenNoConventionMatch_ShouldRegisterSelf()
+    {
+        // Act
+        var result = Types.From(typeof(LegacyOrderProcessor)).AsDefaultInterfacesOrSelf().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(LegacyOrderProcessor), descriptor.ServiceType);
+        Assert.Equal(typeof(LegacyOrderProcessor), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void AsDefaultNonSystemInterfacesOrSelf_WhenConventionMatchesNonSystem_ShouldRegisterMatchingInterface()
+    {
+        // Act
+        var result = Types.From(typeof(CustomerService)).AsDefaultNonSystemInterfacesOrSelf().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(CustomerService), descriptor.ImplementationType);
+        Assert.Equal(typeof(ICustomerService), descriptor.ServiceType);
+    }
+
+    [Fact]
+    public void AsDefaultNonSystemInterfacesOrSelf_WhenNoMatch_ShouldRegisterSelf()
+    {
+        // Act
+        var result = Types.From(typeof(Address)).AsDefaultNonSystemInterfacesOrSelf().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(Address), descriptor.ServiceType);
+        Assert.Equal(typeof(Address), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void AsFirstInterfaceOrSelf_WhenInterfacesExist_ShouldRegisterFirstInterface()
+    {
+        // Act
+        var result = Types.From(typeof(CustomerService)).AsFirstInterfaceOrSelf().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(CustomerService), descriptor.ImplementationType);
+        Assert.Contains(descriptor.ServiceType, typeof(CustomerService).GetInterfaces());
+    }
+
+    [Fact]
+    public void AsFirstInterfaceOrSelf_WhenNoInterfaces_ShouldRegisterSelf()
+    {
+        // Act
+        var result = Types.From(typeof(Customer)).AsFirstInterfaceOrSelf().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(Customer), descriptor.ServiceType);
+        Assert.Equal(typeof(Customer), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void AsInterfaceOrSelf_WithBasedOn_ShouldRegisterTopLevelDerivedInterface()
+    {
+        // Act
+        var result = Types
+            .From(typeof(SqlCustomerRepository))
+            .BasedOn(typeof(IRepository<>))
+            .AsInterfaceOrSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(SqlCustomerRepository), descriptor.ImplementationType);
+        Assert.Equal(typeof(ICustomerRepository), descriptor.ServiceType);
+    }
+
+    [Fact]
+    public void AsInterfaceOrSelf_WhenNoMatchingInterface_ShouldRegisterSelf()
+    {
+        // Act
+        var result = Types.From(typeof(Customer)).AsInterfaceOrSelf().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(Customer), descriptor.ServiceType);
+        Assert.Equal(typeof(Customer), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void AsInterfaceOrSelf_T_WhenMatchingInterface_ShouldRegisterInterface()
+    {
+        // Act
+        var result = Types.From(typeof(CustomerService)).AsInterfaceOrSelf<ICustomerService>().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(CustomerService), descriptor.ImplementationType);
+        Assert.Equal(typeof(ICustomerService), descriptor.ServiceType);
+    }
+
+    [Fact]
+    public void AsInterfaceOrSelf_T_WhenTypeHasNoMatchingInterface_ShouldRegisterSelf()
+    {
+        // Act
+        var result = Types.From(typeof(CustomerService)).AsInterfaceOrSelf<IPaymentGateway>().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(CustomerService), descriptor.ServiceType);
+        Assert.Equal(typeof(CustomerService), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void AsInterfaceOrSelf_WithExplicitType_WhenMatching_ShouldRegisterInterface()
+    {
+        // Act
+        var result = Types.From(typeof(CustomerService)).AsInterfaceOrSelf(typeof(ICustomerService)).ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(CustomerService), descriptor.ImplementationType);
+        Assert.Equal(typeof(ICustomerService), descriptor.ServiceType);
+    }
+
+    [Fact]
+    public void AsInterfaceOrSelf_WithExplicitType_WhenNoMatch_ShouldRegisterSelf()
+    {
+        // Act
+        var result = Types.From(typeof(CustomerService)).AsInterfaceOrSelf(typeof(IPaymentGateway)).ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(CustomerService), descriptor.ServiceType);
+        Assert.Equal(typeof(CustomerService), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void AsInterfaceOrSelf_WithExplicitType_WhenTypeIsNull_ShouldThrow()
+    {
+        // Act
+        var act = () => Types.From(typeof(Customer)).AsInterfaceOrSelf((Type)null!);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(act);
+    }
+
+    [Fact]
+    public void AsInterfacesOrSelf_WithMultipleBaseTypes_ShouldRegisterDerivedInterfaces()
+    {
+        // Act
+        var result = Types
+            .From(typeof(CustomerService), typeof(OrderService))
+            .AsInterfacesOrSelf(typeof(ICustomerService), typeof(IOrderService))
+            .ToServiceCollection();
+
+        // Assert
+        Assert.Contains(
+            result,
+            d => d.ImplementationType == typeof(CustomerService) && d.ServiceType == typeof(ICustomerService)
+        );
+        Assert.Contains(
+            result,
+            d => d.ImplementationType == typeof(OrderService) && d.ServiceType == typeof(IOrderService)
+        );
+    }
+
+    [Fact]
+    public void AsInterfacesOrSelf_WhenNoMatchingInterface_ShouldRegisterSelf()
+    {
+        // Act
+        var result = Types.From(typeof(Customer)).AsInterfacesOrSelf(typeof(ICustomerService)).ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(Customer), descriptor.ServiceType);
+        Assert.Equal(typeof(Customer), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void AsInterfacesOrSelf_WhenInterfaceTypesIsNull_ShouldThrow()
+    {
+        // Act
+        var act = () => Types.From(typeof(Customer)).AsInterfacesOrSelf((Type[])null!);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(act);
+    }
+
+    [Fact]
+    public void AsInterfaceOrSelf_WithMixedTypes_ShouldRegisterInterfacesAndSelfPerType()
+    {
+        // Act
+        var result = Types.From(typeof(CustomerService), typeof(Customer)).AsInterfaceOrSelf().ToServiceCollection();
+
+        // Assert
+        var serviceTypes = result.Select(d => d.ServiceType).ToArray();
+        Assert.Contains(typeof(ICustomerService), serviceTypes);
+        Assert.Contains(typeof(Customer), serviceTypes);
+        Assert.DoesNotContain(typeof(CustomerService), serviceTypes);
+    }
+
+    [Fact]
+    public void AsAllInterfaces_WhenNoInterfaces_ShouldNotRegister()
+    {
+        // Act
+        var result = Types.From(typeof(Customer)).AsAllInterfaces().ToServiceCollection();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AsAllNonSystemInterfaces_WhenNoInterfaces_ShouldNotRegister()
+    {
+        // Act
+        var result = Types.From(typeof(Customer)).AsAllNonSystemInterfaces().ToServiceCollection();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AsAllNonSystemInterfaces_WhenOnlySystemInterfaces_ShouldNotRegister()
+    {
+        // Act
+        var result = Types.From(typeof(Address)).AsAllNonSystemInterfaces().ToServiceCollection();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AsDefaultNonSystemInterfaces_WhenNoMatch_ShouldNotRegister()
+    {
+        // Act
+        var result = Types.From(typeof(LegacyOrderProcessor)).AsDefaultNonSystemInterfaces().ToServiceCollection();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AsInterface_WhenNoMatchingInterface_ShouldNotRegister()
+    {
+        // Act
+        var result = Types.From(typeof(Customer)).AsInterface().ToServiceCollection();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AsInterface_WithExplicitType_WhenNoMatch_ShouldNotRegister()
+    {
+        // Act
+        var result = Types.From(typeof(CustomerService)).AsInterface(typeof(IPaymentGateway)).ToServiceCollection();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AsInterfaces_WhenNoMatchingInterface_ShouldNotRegister()
+    {
+        // Act
+        var result = Types.From(typeof(Customer)).AsInterfaces(typeof(ICustomerService)).ToServiceCollection();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AsInterfaces_WhenInterfaceTypesIsNull_ShouldThrow()
+    {
+        // Act
+        var act = () => Types.From(typeof(Customer)).AsInterfaces((Type[])null!);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(act);
     }
 }


### PR DESCRIPTION
Adds in fallback to all interface selection extensions so that if the type has no interfaces it will register as itself.

Closes #46