### PR TITLE
#45 - Add in service lifetime selection by attribute

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -22,6 +22,7 @@ See [decorators.md](decorators.md).
 - **Type filtering** via `Where`, `BasedOn`, `InNamespace`, `NameEndsWith`, and generic-type filters
 - **Service selection** via `AsInterface`, `AsDefaultInterfaces`, `AsSelf`, `AsBase`, and custom delegates
 - **Keyed registration** with auto-detection or custom key selectors
+- **Lifetime selection** per chain (`AsSingleton`, `AsScoped`, `AsTransient`) or per type from a `[Lifetime]` attribute (`AsLifetimeByAttribute`)
 - **Sharing modes** that control whether one impl registered against multiple service types resolves to a shared instance, a factory-resolved dependent, or independent instances per service type
 
 See [registration.md](registration.md) for the narrative guide and [registration-cheat-sheet.md](registration-cheat-sheet.md) for a one-page API reference.

--- a/docs/registration-cheat-sheet.md
+++ b/docs/registration-cheat-sheet.md
@@ -87,16 +87,18 @@ See [service-key-selectors.md](service-key-selectors.md) for examples.
 
 The lifetime-selection stage (on `ServiceLifetimeSelector`). Each call returns a `ServiceSource` — finish it with `.ToServiceCollection()` or a bulk-add (`services.AddSingleton(...)`, `services.Add(...)`).
 
-| Method                                 | Lifetime  | `SharingMode`                                                        |
-|----------------------------------------|-----------|----------------------------------------------------------------------|
-| `AsSingleton()`                        | Singleton | `SharedComponent`                                                    |
-| `AsSingletonDependent()`               | Singleton | `Dependent`                                                          |
-| `AsSingletonIndependent()`             | Singleton | `Independent`                                                        |
-| `AsScoped()`                           | Scoped    | `SharedComponent`                                                    |
-| `AsScopedDependent()`                  | Scoped    | `Dependent`                                                          |
-| `AsScopedIndependent()`                | Scoped    | `Independent`                                                        |
-| `AsTransient()`                        | Transient | `Independent` (only valid mode)                                      |
-| `AsLifetime(lifetime [, sharingMode])` | Custom    | Defaults to `Independent` for Transient, `SharedComponent` otherwise |
+| Method                                    | Lifetime  | `SharingMode`                                                                                 |
+|-------------------------------------------|-----------|-----------------------------------------------------------------------------------------------|
+| `AsSingleton()`                           | Singleton | `SharedComponent`                                                                             |
+| `AsSingletonDependent()`                  | Singleton | `Dependent`                                                                                   |
+| `AsSingletonIndependent()`                | Singleton | `Independent`                                                                                 |
+| `AsScoped()`                              | Scoped    | `SharedComponent`                                                                             |
+| `AsScopedDependent()`                     | Scoped    | `Dependent`                                                                                   |
+| `AsScopedIndependent()`                   | Scoped    | `Independent`                                                                                 |
+| `AsTransient()`                           | Transient | `Independent` (only valid mode)                                                               |
+| `AsLifetime(lifetime [, sharingMode])`    | Custom    | Defaults to `Independent` for Transient, `SharedComponent` otherwise                          |
+| `AsLifetime(Func<Type, ServiceLifetime>)` | Per type  | `SharedComponent`, except Transient components (registered `Independent`)                     |
+| `AsLifetimeByAttribute(...)`              | Per type  | Lifetime from a `[Lifetime]` / `IServiceLifetimeProvider` attribute (falls back to Singleton) |
 
 `SharingMode` controls what happens when one impl is registered against multiple service types:
 

--- a/docs/shared-components.md
+++ b/docs/shared-components.md
@@ -72,6 +72,98 @@ Sharing behavior is controlled by the `SharingMode` enum:
 
 Calling `AsLifetime(ServiceLifetime.Transient, SharingMode.SharedComponent)` or `AsLifetime(ServiceLifetime.Transient, SharingMode.Dependent)` throws `ArgumentException`. Sharing cannot apply to transient services, so the mismatch is surfaced eagerly rather than silently ignored.
 
+The methods above apply **one** lifetime to the whole chain. To choose a lifetime **per implementation type**, use `AsLifetime(Func<Type, ServiceLifetime>)` or read it from an attribute with `AsLifetimeByAttribute` (see [Lifetime from attributes](#lifetime-from-attributes)). Both use `SharingMode.SharedComponent`, except that any component whose resolved lifetime is `Transient` is registered `Independent` — a transient can never share an instance.
+
+## Lifetime from attributes
+
+Instead of applying one lifetime to the whole chain, `AsLifetimeByAttribute` reads the lifetime from an **attribute applied to the implementation type**. This keeps the lifetime declaration next to the implementation it belongs to, so a single convention scan can register singletons, scoped services, and transients side by side. All overloads share the same rules:
+
+- **Inherited attributes are inspected by default.** Each overload has a companion that takes a leading `bool inherited` parameter; pass `false` to consider only attributes declared directly on the implementation type.
+- **No match means Singleton.** Implementation types without a matching attribute fall back to `ServiceLifetime.Singleton` — the same lifetime a skipped lifetime stage would use.
+- **A single match is required.** If a type carries more than one matching attribute, an `AmbiguousMatchException` is thrown when the chain is enumerated.
+- **Transient components are registered independently.** Sharing defaults to `SharingMode.SharedComponent`, but a component whose resolved lifetime is `Transient` is registered `Independent`, because a transient can never share an instance.
+
+## `AsLifetimeByAttribute()`
+
+Reads the lifetime from any attribute that implements the library's `IServiceLifetimeProvider` interface. The library ships a ready-made one — `[Lifetime]` — so the common case needs no custom attribute:
+
+```csharp
+services.Add(
+    Classes.From(typeof(CustomerService), typeof(OrderService))
+        .AsInterface()
+        .AsLifetimeByAttribute()
+);
+```
+
+Given:
+
+```csharp
+[Lifetime(ServiceLifetime.Singleton)]
+public class CustomerService : ICustomerService { }
+
+[Lifetime(ServiceLifetime.Scoped)]
+public class OrderService : IOrderService { }
+```
+
+Registers:
+
+```
+CustomerService → ICustomerService (Singleton)
+OrderService    → IOrderService    (Scoped)
+```
+
+`[Lifetime]` is declared `Inherited = false` — matching `[Keyed]` — so a lifetime does not flow to subclasses by default (this also keeps runtime and source-generated registration in agreement, since a source generator only sees attributes declared directly on a type). Types with no `IServiceLifetimeProvider` attribute fall back to `ServiceLifetime.Singleton`.
+
+To declare lifetimes with your own attribute instead, implement `IServiceLifetimeProvider`:
+
+```csharp
+public interface IServiceLifetimeProvider
+{
+    ServiceLifetime Lifetime { get; }
+}
+```
+
+Whether such a custom attribute is picked up on derived types follows *its* own `[AttributeUsage(Inherited = …)]`; pass `AsLifetimeByAttribute(inherited: false)` to ignore inherited attributes.
+
+## `AsLifetimeByAttribute<TAttribute>(Func<TAttribute, ServiceLifetime>)`
+
+Projects a specific attribute — one that need not know anything about `IServiceLifetimeProvider` — through a selector. `TAttribute` may be a concrete attribute type or an interface implemented by one or more attributes (marker-interface matching):
+
+```csharp
+Classes.FromThisAssembly()
+    .BasedOn<IStore>()
+    .AsInterface()
+    .AsLifetimeByAttribute<LifestyleAttribute>(attribute => attribute.Lifetime)
+```
+
+Given:
+
+```csharp
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class LifestyleAttribute(ServiceLifetime lifetime) : Attribute
+{
+    public ServiceLifetime Lifetime => lifetime;
+}
+
+[Lifestyle(ServiceLifetime.Scoped)]
+public class CustomerStore : IStore { }
+```
+
+Registers `CustomerStore → IStore (Scoped)`. Types without the attribute fall back to `ServiceLifetime.Singleton`. An `inherited` overload — `AsLifetimeByAttribute<TAttribute>(bool inherited, Func<TAttribute, ServiceLifetime>)` — controls whether inherited attributes are inspected.
+
+## `AsLifetimeByAttribute(Type, Func<Attribute, ServiceLifetime>)`
+
+The non-generic form, for when the attribute type is only known at runtime. The selector receives the matching attribute as `Attribute`, so it is cast before the lifetime is read:
+
+```csharp
+Classes.FromThisAssembly()
+    .BasedOn<IStore>()
+    .AsInterface()
+    .AsLifetimeByAttribute(typeof(LifestyleAttribute), attribute => ((LifestyleAttribute)attribute).Lifetime)
+```
+
+This registers the same lifetimes as the generic overload above. An `inherited` overload — `AsLifetimeByAttribute(Type, bool inherited, Func<Attribute, ServiceLifetime>)` — is also available.
+
 ## `SharedComponent` vs `Dependent`
 
 Both modes produce one shared instance behind every service type. They differ in **who registers the implementation**:
@@ -153,3 +245,5 @@ The `TypeFilter.ConstructedGenericTypes()` and `TypeFilter.GenericTypeDefinition
 | Each service type should have its own instance                          | `AsSingletonIndependent()` / `AsScopedIndependent()`         |
 | New instance on every resolution                                        | `AsTransient()`                                              |
 | Open generic mapped to multiple service types                           | `AsSingletonIndependent()` / `AsScopedIndependent()`         |
+| Lifetime declared per type by an attribute                              | `AsLifetimeByAttribute(...)`                                 |
+| Lifetime computed per type by a delegate                                | `AsLifetime(Func<Type, ServiceLifetime>)`                    |

--- a/fixtures/Fixtures.SmallProject/Attributes/AttributeFixtures.cs
+++ b/fixtures/Fixtures.SmallProject/Attributes/AttributeFixtures.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using ZCrew.Extensions.DependencyInjection.Registration;
 
 namespace Fixtures.SmallProject.Attributes;
@@ -131,3 +132,79 @@ public class KeyedDerived : KeyedBase;
 public class InheritableKeyedBase;
 
 public class InheritableKeyedDerived : InheritableKeyedBase;
+
+/// <summary>
+///     Marker interface implemented by attributes that carry a <see cref="ServiceLifetime"/>. Exercises attribute
+///     filtering by an interface the attribute implements (rather than by the concrete attribute type), including
+///     reading a property the interface defines.
+/// </summary>
+public interface ILifestyleAware
+{
+    ServiceLifetime Lifetime { get; }
+}
+
+/// <summary>
+///     A projection attribute exposing a <see cref="ServiceLifetime"/>, unrelated to
+///     <see cref="IServiceLifetimeProvider"/>. Declared <c>Inherited = true</c> (the default) so it also exercises
+///     the <c>inherited</c> flag on the projection overloads.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class)]
+public class LifestyleAttribute(ServiceLifetime lifetime) : Attribute, ILifestyleAware
+{
+    public ServiceLifetime Lifetime => lifetime;
+}
+
+/// <summary>
+///     A second <see cref="IServiceLifetimeProvider"/> attribute. The shipped <see cref="LifetimeAttribute"/> is
+///     <c>AllowMultiple = false</c>, so a distinct provider is needed to give a single type two lifetime attributes
+///     (the ambiguous-match path). Declared <c>Inherited = true</c> (the default) so it also exercises the
+///     <c>inherited</c> flag on the <see cref="IServiceLifetimeProvider"/> path.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class)]
+public class AltLifetimeAttribute(ServiceLifetime lifetime) : Attribute, IServiceLifetimeProvider
+{
+    public ServiceLifetime Lifetime => lifetime;
+}
+
+public interface ILifetimeAlpha;
+
+public interface ILifetimeBeta;
+
+[Lifetime(ServiceLifetime.Scoped)]
+public class ScopedLifetimeStore;
+
+[Lifetime(ServiceLifetime.Transient)]
+public class TransientLifetimeStore;
+
+[Lifetime(ServiceLifetime.Singleton)]
+public class SingletonLifetimeStore;
+
+[Lifetime(ServiceLifetime.Scoped)]
+[AltLifetime(ServiceLifetime.Transient)]
+public class MultiLifetimeStore;
+
+// [Lifetime] is declared Inherited = false, so its lifetime does not flow to LifetimeDerived.
+[Lifetime(ServiceLifetime.Scoped)]
+public class LifetimeBase;
+
+public class LifetimeDerived : LifetimeBase;
+
+// AltLifetime is inheritable, so it exercises the inherited flag on the IServiceLifetimeProvider path.
+[AltLifetime(ServiceLifetime.Scoped)]
+public class InheritableLifetimeBase;
+
+public class InheritableLifetimeDerived : InheritableLifetimeBase;
+
+// Lifestyle is inheritable, so it exercises the inherited flag on the projection overloads.
+[Lifestyle(ServiceLifetime.Scoped)]
+public class LifestyleBase;
+
+public class LifestyleDerived : LifestyleBase;
+
+// Multi-interface implementations that declare their own lifetime, for verifying that Singleton components still
+// share one instance while Transient components are registered independently.
+[Lifetime(ServiceLifetime.Singleton)]
+public class SingletonMultiStore : ILifetimeAlpha, ILifetimeBeta;
+
+[Lifetime(ServiceLifetime.Transient)]
+public class TransientMultiStore : ILifetimeAlpha, ILifetimeBeta;

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/IServiceLifetimeProvider.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/IServiceLifetimeProvider.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ZCrew.Extensions.DependencyInjection.Registration;
+
+/// <summary>
+///     Represents a provider for a <see cref="ServiceDescriptor.Lifetime"/>.
+/// </summary>
+/// <seealso cref="LifetimeAttribute"/>
+public interface IServiceLifetimeProvider
+{
+    /// <summary>
+    ///     The service lifetime to apply to the registration.
+    /// </summary>
+    ServiceLifetime Lifetime { get; }
+}

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/LifetimeAttribute.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/LifetimeAttribute.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ZCrew.Extensions.DependencyInjection.Registration;
+
+/// <summary>
+///     Declares the <see cref="ServiceLifetime"/> for a service. This can be detected automatically with
+///     <see cref="ServiceLifetimeSelectorExtensions.AsLifetimeByAttribute(ServiceLifetimeSelector)"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
+public class LifetimeAttribute : Attribute, IServiceLifetimeProvider
+{
+    /// <summary>
+    ///     Initializes a new <see cref="LifetimeAttribute"/> specifying the lifetime for this service.
+    /// </summary>
+    /// <param name="lifetime">The service lifetime to apply to the registration.</param>
+    public LifetimeAttribute(ServiceLifetime lifetime)
+    {
+        Lifetime = lifetime;
+    }
+
+    /// <inheritdoc />
+    public ServiceLifetime Lifetime { get; }
+}

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceComponent.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceComponent.cs
@@ -9,9 +9,20 @@ internal readonly record struct ServiceComponent
 {
     private readonly Type implementation;
     private readonly IReadOnlyList<Type> services;
-    private readonly ServiceLifetime lifetime = ServiceLifetime.Singleton;
+    private readonly ServiceLifetime? lifetime;
+    private readonly Func<Type, ServiceLifetime>? lifetimeProvider;
     private readonly object? serviceKey;
     private readonly Func<Type, Type, object?>? serviceKeyProvider;
+
+    /// <summary>
+    ///     The effective lifetime for this component: the value produced by the <see cref="lifetimeProvider"/> when
+    ///     one is set (evaluated against the implementation type), otherwise the fixed <see cref="lifetime"/>.
+    /// </summary>
+    /// <remarks>
+    ///     Either <see cref="implementation"/> or <see cref="lifetime"/> is set so the fallback is never hit.
+    /// </remarks>
+    private ServiceLifetime EffectiveLifetime =>
+        this.lifetimeProvider?.Invoke(this.implementation) ?? this.lifetime ?? ServiceLifetime.Singleton;
 
     /// <summary>
     ///     Create a new service component.
@@ -30,12 +41,14 @@ internal readonly record struct ServiceComponent
     /// <param name="implementation">The implementation type.</param>
     /// <param name="services">The services to register for the <paramref name="implementation"/>.</param>
     /// <param name="lifetime">The service lifetime.</param>
+    /// <param name="lifetimeProvider">The dynamic service lifetime provider.</param>
     /// <param name="serviceKey">The shared service key.</param>
     /// <param name="serviceKeyProvider">The dynamic service key provider.</param>
     private ServiceComponent(
         Type implementation,
         IReadOnlyList<Type> services,
-        ServiceLifetime lifetime,
+        ServiceLifetime? lifetime,
+        Func<Type, ServiceLifetime>? lifetimeProvider,
         object? serviceKey,
         Func<Type, Type, object?>? serviceKeyProvider
     )
@@ -43,6 +56,7 @@ internal readonly record struct ServiceComponent
         this.implementation = implementation;
         this.services = services;
         this.lifetime = lifetime;
+        this.lifetimeProvider = lifetimeProvider;
         this.serviceKey = serviceKey;
         this.serviceKeyProvider = serviceKeyProvider;
     }
@@ -53,7 +67,7 @@ internal readonly record struct ServiceComponent
     /// <param name="lifetime">The lifetime.</param>
     public ServiceComponent WithLifetime(ServiceLifetime lifetime)
     {
-        if (lifetime == this.lifetime)
+        if (lifetime == this.lifetime && this.lifetimeProvider == null)
         {
             return this;
         }
@@ -62,6 +76,29 @@ internal readonly record struct ServiceComponent
             this.implementation,
             this.services,
             lifetime,
+            null,
+            this.serviceKey,
+            this.serviceKeyProvider
+        );
+    }
+
+    /// <summary>
+    ///     Indirectly set the <see cref="ServiceDescriptor.Lifetime"/> of the future <see cref="ServiceDescriptor"/>
+    ///     instances by evaluating the lifetime against the implementation type when resolving the descriptors.
+    /// </summary>
+    /// <param name="lifetimeProvider">The dynamic service lifetime provider.</param>
+    public ServiceComponent WithLifetime(Func<Type, ServiceLifetime> lifetimeProvider)
+    {
+        if (lifetimeProvider == this.lifetimeProvider)
+        {
+            return this;
+        }
+
+        return new ServiceComponent(
+            this.implementation,
+            this.services,
+            this.lifetime,
+            lifetimeProvider,
             this.serviceKey,
             this.serviceKeyProvider
         );
@@ -78,7 +115,14 @@ internal readonly record struct ServiceComponent
             return this;
         }
 
-        return new ServiceComponent(this.implementation, this.services, this.lifetime, serviceKey, null);
+        return new ServiceComponent(
+            this.implementation,
+            this.services,
+            this.lifetime,
+            this.lifetimeProvider,
+            serviceKey,
+            null
+        );
     }
 
     /// <summary>
@@ -93,7 +137,14 @@ internal readonly record struct ServiceComponent
             return this;
         }
 
-        return new ServiceComponent(this.implementation, this.services, this.lifetime, null, serviceKeyProvider);
+        return new ServiceComponent(
+            this.implementation,
+            this.services,
+            this.lifetime,
+            this.lifetimeProvider,
+            null,
+            serviceKeyProvider
+        );
     }
 
     /// <summary>
@@ -102,7 +153,10 @@ internal readonly record struct ServiceComponent
     ///     service types shares its instance.
     /// </summary>
     /// <param name="serviceCollection">The service collection to add the <see cref="ServiceDescriptor"/>(s) to.</param>
-    /// <param name="sharingMode">The sharing mode to apply to this component.</param>
+    /// <param name="sharingMode">
+    ///     The sharing mode to apply to this component or <see langword="null"/> if the lifetime is dynamic and the
+    ///     default sharing mode should be used instead.
+    /// </param>
     /// <returns>The resulting service descriptors.</returns>
     /// <exception cref="InvalidOperationException">
     ///     Thrown when sharing is requested for an open generic implementation. Microsoft's container does not
@@ -110,7 +164,7 @@ internal readonly record struct ServiceComponent
     ///     (<see href="https://github.com/dotnet/runtime/issues/41050"/>) which is required to share an instance
     ///     across multiple service types.
     /// </exception>
-    public void AddServiceDescriptors(IServiceCollection serviceCollection, SharingMode sharingMode)
+    public void AddServiceDescriptors(IServiceCollection serviceCollection, SharingMode? sharingMode)
     {
         // No services to register
         if (this.services.Count == 0)
@@ -118,8 +172,12 @@ internal readonly record struct ServiceComponent
             return;
         }
 
+        // When dealing with a dynamic lifetime the sharing mode can't be set
+        var componentSharingMode = sharingMode ?? EffectiveLifetime.DefaultSharingMode();
+
         // Don't need to bother sharing with only one registration
-        if (sharingMode == SharingMode.Independent || this.services.Count == 1)
+        if (componentSharingMode == SharingMode.Independent || this.services.Count == 1
+        )
         {
             AddIndependentServiceDescriptors(serviceCollection);
             return;
@@ -136,7 +194,7 @@ internal readonly record struct ServiceComponent
                 "For more information, see: https://github.com/dotnet/runtime/issues/41050");
         }
 
-        if (sharingMode == SharingMode.Dependent)
+        if (componentSharingMode == SharingMode.Dependent)
         {
             AddDependentServiceDescriptors(serviceCollection);
             return;
@@ -205,30 +263,32 @@ internal readonly record struct ServiceComponent
 
     private ServiceDescriptor Registration(Type service)
     {
+        var lifetime = EffectiveLifetime;
         if (this.serviceKeyProvider != null)
         {
             var specificServiceKey = this.serviceKeyProvider(this.implementation, service);
-            return new ServiceDescriptor(service, specificServiceKey, this.implementation, this.lifetime);
+            return new ServiceDescriptor(service, specificServiceKey, this.implementation, lifetime);
         }
         // If the service key is null then it's a non-keyed service anyway
-        return new ServiceDescriptor(service, this.serviceKey, this.implementation, this.lifetime);
+        return new ServiceDescriptor(service, this.serviceKey, this.implementation, lifetime);
     }
 
     private ServiceDescriptor FactoryRegistration(Type service, Func<IServiceProvider, object?, object> factory)
     {
+        var lifetime = EffectiveLifetime;
         if (this.serviceKeyProvider != null)
         {
             var specificServiceKey = this.serviceKeyProvider(this.implementation, service);
-            return new ServiceDescriptor(service, specificServiceKey, factory, this.lifetime);
+            return new ServiceDescriptor(service, specificServiceKey, factory, lifetime);
         }
 
         // If the service key is null then it's a non-keyed service anyway
-        return new ServiceDescriptor(service, this.serviceKey, factory, this.lifetime);
+        return new ServiceDescriptor(service, this.serviceKey, factory, lifetime);
     }
 
     private ServiceDescriptor SharedComponentRegistration(Type service, SharedComponentKey key)
     {
-        return new ServiceDescriptor(service, key, service, this.lifetime);
+        return new ServiceDescriptor(service, key, service, EffectiveLifetime);
     }
 
     private readonly record struct SharedComponentKey

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceLifetimeExtensions.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceLifetimeExtensions.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ZCrew.Extensions.DependencyInjection.Registration;
+
+/// <summary>
+///     Internal helpers for the <see cref="ServiceLifetime"/> enum.
+/// </summary>
+internal static class ServiceLifetimeExtensions
+{
+    extension(ServiceLifetime lifetime)
+    {
+        /// <summary>
+        ///     The <see cref="SharingMode"/> applied by default for this lifetime.
+        ///     <see cref="ServiceLifetime.Transient"/> maps to <see cref="SharingMode.Independent"/> — a transient
+        ///     service constructs a new instance on every resolution, so sharing an instance is never meaningful.
+        ///     All other lifetimes map to <see cref="SharingMode.SharedComponent"/>.
+        /// </summary>
+        internal SharingMode DefaultSharingMode()
+        {
+            return lifetime == ServiceLifetime.Transient ? SharingMode.Independent : SharingMode.SharedComponent;
+        }
+    }
+}

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceLifetimeSelector.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceLifetimeSelector.cs
@@ -49,4 +49,26 @@ public class ServiceLifetimeSelector : ServiceSource
 
         return new ServiceSource(this.components.Select(component => component.WithLifetime(lifetime)), sharingMode);
     }
+
+    /// <summary>
+    ///     Returns a new <see cref="ServiceSource"/> whose descriptors take the <see cref="ServiceLifetime"/> produced
+    ///     by <paramref name="lifetimeSelector"/> for each implementation type. The default sharing mode is used: for
+    ///     <see cref="ServiceLifetime.Transient"/> that is <see cref="SharingMode.Independent"/>; for others it is
+    ///     <see cref="SharingMode.SharedComponent"/>.
+    /// </summary>
+    /// <param name="lifetimeSelector">
+    ///     A function that receives the implementation type and returns the service lifetime.
+    /// </param>
+    /// <example>
+    ///     <code>
+    ///     Classes.From(typeof(CustomerService), typeof(OrderService))
+    ///         .AsInterface()
+    ///         .AsLifetime(type => type == typeof(OrderService) ? ServiceLifetime.Scoped : ServiceLifetime.Singleton)
+    ///     </code>
+    /// </example>
+    public ServiceSource AsLifetime(Func<Type, ServiceLifetime> lifetimeSelector)
+    {
+        ArgumentNullException.ThrowIfNull(lifetimeSelector);
+        return new ServiceSource(this.components.Select(component => component.WithLifetime(lifetimeSelector)), null);
+    }
 }

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceLifetimeSelectorExtensions.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceLifetimeSelectorExtensions.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace ZCrew.Extensions.DependencyInjection.Registration;
@@ -17,10 +18,7 @@ public static class ServiceLifetimeSelectorExtensions
         /// <param name="lifetime">The target service lifetime.</param>
         public ServiceSource AsLifetime(ServiceLifetime lifetime)
         {
-            // Transient types won't benefit from sharing an instance
-            var defaultSharingMode =
-                lifetime == ServiceLifetime.Transient ? SharingMode.Independent : SharingMode.SharedComponent;
-            return selector.AsLifetime(lifetime, defaultSharingMode);
+            return selector.AsLifetime(lifetime, lifetime.DefaultSharingMode());
         }
 
         /// <summary>
@@ -90,6 +88,151 @@ public static class ServiceLifetimeSelectorExtensions
         public ServiceSource AsTransient()
         {
             return selector.AsLifetime(ServiceLifetime.Transient, SharingMode.Independent);
+        }
+
+        /// <summary>
+        ///     Assigns a service lifetime to each registration from the <see cref="IServiceLifetimeProvider.Lifetime"/>
+        ///     of an <see cref="IServiceLifetimeProvider"/> attribute applied to the implementation type, inspecting
+        ///     inherited attributes. Implementation types without such an attribute fall back to
+        ///     <see cref="ServiceLifetime.Singleton"/>.
+        /// </summary>
+        /// <example>
+        ///     <code>
+        ///     Classes.FromThisAssembly().BasedOn&lt;IPaymentGateway&gt;().AsInterface().AsLifetimeByAttribute()
+        ///     </code>
+        /// </example>
+        /// <exception cref="AmbiguousMatchException">
+        ///     Thrown when an implementation type has more than one <see cref="IServiceLifetimeProvider"/> attribute.
+        /// </exception>
+        public ServiceSource AsLifetimeByAttribute()
+        {
+            return selector.AsLifetimeByAttribute(true);
+        }
+
+        /// <summary>
+        ///     Assigns a service lifetime to each registration from the <see cref="IServiceLifetimeProvider.Lifetime"/>
+        ///     of an <see cref="IServiceLifetimeProvider"/> attribute applied to the implementation type.
+        ///     Implementation types without such an attribute fall back to <see cref="ServiceLifetime.Singleton"/>.
+        /// </summary>
+        /// <param name="inherited">
+        ///     <see langword="true"/> to inspect the ancestors of the implementation type; otherwise,
+        ///     <see langword="false"/>.
+        /// </param>
+        /// <exception cref="AmbiguousMatchException">
+        ///     Thrown when an implementation type has more than one <see cref="IServiceLifetimeProvider"/> attribute.
+        /// </exception>
+        public ServiceSource AsLifetimeByAttribute(bool inherited)
+        {
+            return selector.AsLifetime(type =>
+                type.GetAttribute<IServiceLifetimeProvider>(inherited)?.Lifetime ?? ServiceLifetime.Singleton
+            );
+        }
+
+        /// <summary>
+        ///     Assigns a service lifetime to each registration by projecting a <typeparamref name="TAttribute"/>
+        ///     applied to the implementation type through <paramref name="lifetimeSelector"/>, inspecting inherited
+        ///     attributes. Implementation types without the attribute fall back to
+        ///     <see cref="ServiceLifetime.Singleton"/>.
+        /// </summary>
+        /// <param name="lifetimeSelector">A function that maps the matching attribute to the service lifetime.</param>
+        /// <typeparam name="TAttribute">The attribute type or marker interface to search for.</typeparam>
+        /// <example>
+        ///     <code>
+        ///     Classes.FromThisAssembly().BasedOn&lt;IPaymentGateway&gt;().AsInterface()
+        ///         .AsLifetimeByAttribute&lt;LifestyleAttribute&gt;(attribute => attribute.Lifetime)
+        ///     </code>
+        /// </example>
+        /// <exception cref="AmbiguousMatchException">
+        ///     Thrown when an implementation type has more than one matching <typeparamref name="TAttribute"/>.
+        /// </exception>
+        public ServiceSource AsLifetimeByAttribute<TAttribute>(Func<TAttribute, ServiceLifetime> lifetimeSelector)
+            where TAttribute : class
+        {
+            return selector.AsLifetimeByAttribute(true, lifetimeSelector);
+        }
+
+        /// <summary>
+        ///     Assigns a service lifetime to each registration by projecting a <typeparamref name="TAttribute"/>
+        ///     applied to the implementation type through <paramref name="lifetimeSelector"/>. Implementation types
+        ///     without the attribute fall back to <see cref="ServiceLifetime.Singleton"/>.
+        /// </summary>
+        /// <param name="inherited">
+        ///     <see langword="true"/> to inspect the ancestors of the implementation type; otherwise,
+        ///     <see langword="false"/>.
+        /// </param>
+        /// <param name="lifetimeSelector">A function that maps the matching attribute to the service lifetime.</param>
+        /// <typeparam name="TAttribute">The attribute type or marker interface to search for.</typeparam>
+        /// <exception cref="AmbiguousMatchException">
+        ///     Thrown when an implementation type has more than one matching <typeparamref name="TAttribute"/>.
+        /// </exception>
+        public ServiceSource AsLifetimeByAttribute<TAttribute>(
+            bool inherited,
+            Func<TAttribute, ServiceLifetime> lifetimeSelector
+        )
+            where TAttribute : class
+        {
+            ArgumentNullException.ThrowIfNull(lifetimeSelector);
+            return selector.AsLifetime(type =>
+            {
+                var attribute = type.GetAttribute<TAttribute>(inherited);
+                return attribute != null ? lifetimeSelector(attribute) : ServiceLifetime.Singleton;
+            });
+        }
+
+        /// <summary>
+        ///     Assigns a service lifetime to each registration by projecting an attribute assignable to
+        ///     <paramref name="attributeType"/> applied to the implementation type through
+        ///     <paramref name="lifetimeSelector"/>, inspecting inherited attributes. Implementation types without a
+        ///     matching attribute fall back to <see cref="ServiceLifetime.Singleton"/>.
+        /// </summary>
+        /// <param name="attributeType">The attribute type or marker interface to search for.</param>
+        /// <param name="lifetimeSelector">A function that maps the matching attribute to the service lifetime.</param>
+        /// <example>
+        ///     <code>
+        ///     Classes.FromThisAssembly().BasedOn&lt;IPaymentGateway&gt;().AsInterface()
+        ///         .AsLifetimeByAttribute(typeof(LifestyleAttribute), attribute => ((LifestyleAttribute)attribute).Lifetime)
+        ///     </code>
+        /// </example>
+        /// <exception cref="AmbiguousMatchException">
+        ///     Thrown when an implementation type has more than one attribute assignable to
+        ///     <paramref name="attributeType"/>.
+        /// </exception>
+        public ServiceSource AsLifetimeByAttribute(
+            Type attributeType,
+            Func<Attribute, ServiceLifetime> lifetimeSelector
+        )
+        {
+            return selector.AsLifetimeByAttribute(attributeType, true, lifetimeSelector);
+        }
+
+        /// <summary>
+        ///     Assigns a service lifetime to each registration by projecting an attribute assignable to
+        ///     <paramref name="attributeType"/> applied to the implementation type through
+        ///     <paramref name="lifetimeSelector"/>. Implementation types without a matching attribute fall back to
+        ///     <see cref="ServiceLifetime.Singleton"/>.
+        /// </summary>
+        /// <param name="attributeType">The attribute type or marker interface to search for.</param>
+        /// <param name="inherited">
+        ///     <see langword="true"/> to inspect the ancestors of the implementation type; otherwise,
+        ///     <see langword="false"/>.
+        /// </param>
+        /// <param name="lifetimeSelector">A function that maps the matching attribute to the service lifetime.</param>
+        /// <exception cref="AmbiguousMatchException">
+        ///     Thrown when an implementation type has more than one attribute assignable to
+        ///     <paramref name="attributeType"/>.
+        /// </exception>
+        public ServiceSource AsLifetimeByAttribute(
+            Type attributeType,
+            bool inherited,
+            Func<Attribute, ServiceLifetime> lifetimeSelector
+        )
+        {
+            ArgumentNullException.ThrowIfNull(lifetimeSelector);
+            return selector.AsLifetime(type =>
+            {
+                var attribute = type.GetAttribute(attributeType, inherited);
+                return attribute != null ? lifetimeSelector(attribute) : ServiceLifetime.Singleton;
+            });
         }
     }
 }

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceSource.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceSource.cs
@@ -10,9 +10,9 @@ namespace ZCrew.Extensions.DependencyInjection.Registration;
 public class ServiceSource
 {
     private readonly IEnumerable<ServiceComponent> components;
-    private readonly SharingMode sharingMode;
+    private readonly SharingMode? sharingMode;
 
-    internal ServiceSource(IEnumerable<ServiceComponent> components, SharingMode sharingMode)
+    internal ServiceSource(IEnumerable<ServiceComponent> components, SharingMode? sharingMode)
     {
         this.components = components;
         this.sharingMode = sharingMode;

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.UnitTests/ServiceLifetimeSelectorExtensionsTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.UnitTests/ServiceLifetimeSelectorExtensionsTests.cs
@@ -1,4 +1,6 @@
+using System.Reflection;
 using Fixtures.SmallProject.Application.Services;
+using Fixtures.SmallProject.Attributes;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace ZCrew.Extensions.DependencyInjection.Registration.UnitTests;
@@ -58,5 +60,370 @@ public class ServiceLifetimeSelectorExtensionsTests
 
         // Assert
         Assert.Contains(result, d => d.ServiceType == typeof(ICustomerService));
+    }
+
+    [Fact]
+    public void AsLifetime_WhenSelectorProvided_ShouldApplyLifetimePerType()
+    {
+        // Arrange
+        var source = Classes.From(typeof(ScopedLifetimeStore), typeof(TransientLifetimeStore)).AsSelf();
+
+        // Act
+        var result = source
+            .AsLifetime(type =>
+                type == typeof(TransientLifetimeStore) ? ServiceLifetime.Transient : ServiceLifetime.Scoped
+            )
+            .ToServiceCollection();
+
+        // Assert
+        Assert.Contains(
+            result,
+            d => d.ImplementationType == typeof(ScopedLifetimeStore) && d.Lifetime == ServiceLifetime.Scoped
+        );
+        Assert.Contains(
+            result,
+            d => d.ImplementationType == typeof(TransientLifetimeStore) && d.Lifetime == ServiceLifetime.Transient
+        );
+    }
+
+    [Fact]
+    public void AsLifetime_WhenSelectorNull_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        var selector = Classes.From(typeof(ScopedLifetimeStore)).AsSelf();
+
+        // Act
+        var act = () => selector.AsLifetime(null!);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(act);
+    }
+
+    [Fact]
+    public void AsLifetimeByAttribute_WhenProviderYieldsLifetime_ShouldSetLifetime()
+    {
+        // Arrange
+        var source = Classes.From(typeof(ScopedLifetimeStore)).AsSelf();
+
+        // Act
+        var result = source.AsLifetimeByAttribute().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(ServiceLifetime.Scoped, descriptor.Lifetime);
+        Assert.Equal(typeof(ScopedLifetimeStore), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void AsLifetimeByAttribute_WhenNoProviderAttribute_ShouldFallBackToSingleton()
+    {
+        // Arrange
+        var source = Classes.From(typeof(UnmarkedStore)).AsSelf();
+
+        // Act
+        var result = source.AsLifetimeByAttribute().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+        Assert.Equal(typeof(UnmarkedStore), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void AsLifetimeByAttribute_WhenMixedTypes_ShouldApplyLifetimePerType()
+    {
+        // Arrange
+        var source = Classes.From(typeof(ScopedLifetimeStore), typeof(UnmarkedStore)).AsSelf();
+
+        // Act
+        var result = source.AsLifetimeByAttribute().ToServiceCollection();
+
+        // Assert
+        Assert.Contains(
+            result,
+            d => d.ImplementationType == typeof(ScopedLifetimeStore) && d.Lifetime == ServiceLifetime.Scoped
+        );
+        Assert.Contains(
+            result,
+            d => d.ImplementationType == typeof(UnmarkedStore) && d.Lifetime == ServiceLifetime.Singleton
+        );
+    }
+
+    [Fact]
+    public void AsLifetimeByAttribute_WhenAttributeIsNonInherited_ShouldApplyOnlyToDeclaringType()
+    {
+        // Arrange — [Lifetime] is declared Inherited = false, so the lifetime does not flow to derived types
+        var source = Classes.From(typeof(LifetimeBase), typeof(LifetimeDerived)).AsSelf();
+
+        // Act
+        var result = source.AsLifetimeByAttribute().ToServiceCollection();
+
+        // Assert
+        Assert.Contains(
+            result,
+            d => d.ImplementationType == typeof(LifetimeBase) && d.Lifetime == ServiceLifetime.Scoped
+        );
+        Assert.Contains(
+            result,
+            d => d.ImplementationType == typeof(LifetimeDerived) && d.Lifetime == ServiceLifetime.Singleton
+        );
+    }
+
+    [Fact]
+    public void AsLifetimeByAttribute_WhenInheritedDefaultAndAttributeInheritable_ShouldApplyToDerived()
+    {
+        // Arrange
+        var source = Classes.From(typeof(InheritableLifetimeDerived)).AsSelf();
+
+        // Act
+        var result = source.AsLifetimeByAttribute().ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(ServiceLifetime.Scoped, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public void AsLifetimeByAttribute_WhenInheritedFalse_ShouldFallBackToSingleton()
+    {
+        // Arrange
+        var source = Classes.From(typeof(InheritableLifetimeDerived)).AsSelf();
+
+        // Act
+        var result = source.AsLifetimeByAttribute(inherited: false).ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public void AsLifetimeByAttribute_WhenMultipleProviderAttributes_ShouldThrowAmbiguousMatch()
+    {
+        // Arrange
+        var source = Classes.From(typeof(MultiLifetimeStore)).AsSelf().AsLifetimeByAttribute();
+
+        // Act
+        var act = () => source.ToServiceCollection();
+
+        // Assert
+        Assert.Throws<AmbiguousMatchException>(act);
+    }
+
+    [Fact]
+    public void AsLifetimeByAttribute_T_WhenAttributeProjected_ShouldSetLifetime()
+    {
+        // Arrange
+        var source = Classes.From(typeof(LifestyleBase)).AsSelf();
+
+        // Act
+        var result = source.AsLifetimeByAttribute<LifestyleAttribute>(a => a.Lifetime).ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(ServiceLifetime.Scoped, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public void AsLifetimeByAttribute_T_WhenMarkerInterface_ShouldSetLifetime()
+    {
+        // Arrange
+        var source = Classes.From(typeof(LifestyleBase)).AsSelf();
+
+        // Act
+        var result = source.AsLifetimeByAttribute<ILifestyleAware>(a => a.Lifetime).ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(ServiceLifetime.Scoped, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public void AsLifetimeByAttribute_T_WhenAttributeMissing_ShouldFallBackToSingleton()
+    {
+        // Arrange
+        var source = Classes.From(typeof(UnmarkedStore)).AsSelf();
+
+        // Act
+        var result = source.AsLifetimeByAttribute<LifestyleAttribute>(a => a.Lifetime).ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public void AsLifetimeByAttribute_T_WhenInheritedDefault_ShouldApplyToDerived()
+    {
+        // Arrange
+        var source = Classes.From(typeof(LifestyleDerived)).AsSelf();
+
+        // Act
+        var result = source.AsLifetimeByAttribute<LifestyleAttribute>(a => a.Lifetime).ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(ServiceLifetime.Scoped, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public void AsLifetimeByAttribute_T_WhenInheritedFalse_ShouldFallBackToSingleton()
+    {
+        // Arrange
+        var source = Classes.From(typeof(LifestyleDerived)).AsSelf();
+
+        // Act
+        var result = source.AsLifetimeByAttribute<LifestyleAttribute>(false, a => a.Lifetime).ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public void AsLifetimeByAttribute_T_WhenMultipleMatchingAttributes_ShouldThrowAmbiguousMatch()
+    {
+        // Arrange
+        var source = Classes
+            .From(typeof(MultiTagged))
+            .AsSelf()
+            .AsLifetimeByAttribute<TagAttribute>(_ => ServiceLifetime.Scoped);
+
+        // Act
+        var act = () => source.ToServiceCollection();
+
+        // Assert
+        Assert.Throws<AmbiguousMatchException>(act);
+    }
+
+    [Fact]
+    public void AsLifetimeByAttribute_T_WhenSelectorNull_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        var selector = Classes.From(typeof(LifestyleBase)).AsSelf();
+
+        // Act
+        var act = () => selector.AsLifetimeByAttribute<LifestyleAttribute>(null!);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(act);
+    }
+
+    [Fact]
+    public void AsLifetimeByAttribute_WhenAttributeTypeProjected_ShouldSetLifetime()
+    {
+        // Arrange
+        var source = Classes.From(typeof(LifestyleBase)).AsSelf();
+
+        // Act
+        var result = source
+            .AsLifetimeByAttribute(typeof(LifestyleAttribute), a => ((LifestyleAttribute)a).Lifetime)
+            .ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(ServiceLifetime.Scoped, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public void AsLifetimeByAttribute_WhenAttributeTypeMissing_ShouldFallBackToSingleton()
+    {
+        // Arrange
+        var source = Classes.From(typeof(UnmarkedStore)).AsSelf();
+
+        // Act
+        var result = source
+            .AsLifetimeByAttribute(typeof(LifestyleAttribute), a => ((LifestyleAttribute)a).Lifetime)
+            .ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public void AsLifetimeByAttribute_WhenAttributeTypeInheritedFalse_ShouldFallBackToSingleton()
+    {
+        // Arrange
+        var source = Classes.From(typeof(LifestyleDerived)).AsSelf();
+
+        // Act
+        var result = source
+            .AsLifetimeByAttribute(typeof(LifestyleAttribute), false, a => ((LifestyleAttribute)a).Lifetime)
+            .ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public void AsLifetimeByAttribute_WhenNonAttributeType_ShouldThrowArgumentException()
+    {
+        // Arrange
+        var source = Classes
+            .From(typeof(LifestyleBase))
+            .AsSelf()
+            .AsLifetimeByAttribute(typeof(string), _ => ServiceLifetime.Scoped);
+
+        // Act
+        var act = () => source.ToServiceCollection();
+
+        // Assert
+        Assert.Throws<ArgumentException>(act);
+    }
+
+    [Fact]
+    public void AsLifetimeByAttribute_WhenAttributeTypeSelectorNull_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        var selector = Classes.From(typeof(LifestyleBase)).AsSelf();
+
+        // Act
+        var act = () => selector.AsLifetimeByAttribute(typeof(LifestyleAttribute), null!);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(act);
+    }
+
+    [Fact]
+    public void AsLifetimeByAttribute_WhenTransientAndMultipleInterfaces_ShouldRegisterIndependently()
+    {
+        // Arrange
+        var source = Classes.From(typeof(TransientMultiStore)).AsAllInterfaces();
+
+        // Act
+        var result = source.AsLifetimeByAttribute().ToServiceCollection();
+
+        // Assert
+        Assert.DoesNotContain(result, d => IsSharedComponentKey(d.ServiceKey));
+        Assert.All(result, d => Assert.Null(d.ImplementationFactory));
+        Assert.All(result, d => Assert.Equal(typeof(TransientMultiStore), d.ImplementationType));
+        Assert.All(result, d => Assert.Equal(ServiceLifetime.Transient, d.Lifetime));
+    }
+
+    [Fact]
+    public void AsLifetimeByAttribute_WhenSingletonAndMultipleInterfaces_ShouldShareOneInstance()
+    {
+        // Arrange
+        var services = Classes
+            .From(typeof(SingletonMultiStore))
+            .AsAllInterfaces()
+            .AsLifetimeByAttribute()
+            .ToServiceCollection();
+        using var provider = services.BuildServiceProvider();
+
+        // Act
+        var alpha = provider.GetRequiredService<ILifetimeAlpha>();
+        var beta = provider.GetRequiredService<ILifetimeBeta>();
+
+        // Assert
+        Assert.Same(alpha, beta);
+        Assert.All(services, d => Assert.Equal(ServiceLifetime.Singleton, d.Lifetime));
+    }
+
+    private static bool IsSharedComponentKey(object? serviceKey)
+    {
+        return serviceKey?.ToString()?.StartsWith("ZCrew:SharedComponent:", StringComparison.Ordinal) == true;
     }
 }


### PR DESCRIPTION
Add in the ability to specify the service lifetime through an attribute. Like the key selection and service selection this comes with a default attribute and attribute interface.

Closes #45