### PR TITLE
#61 - Add in component extensions

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -76,6 +76,80 @@ Component.From<PayPalPaymentGateway>()
 
 Duplicate services are allowed and are collapsed when the component is registered, so `As<IPaymentGateway>().As<IPaymentGateway>()` produces one `IPaymentGateway` registration.
 
+## Selecting services by convention
+
+The `As*` selectors from the [registration chain](service-selectors.md) also work on a component, so services can be
+chosen by convention without giving up the shared instance:
+
+```csharp
+services.Add(Component.From<PayPalPaymentGateway>().AsAllNonSystemInterfaces());
+```
+
+Given:
+
+```csharp
+public interface IPaymentGateway : IDisposable { }
+public class PayPalPaymentGateway : IPaymentGateway { }
+```
+
+Registers:
+
+```
+PayPalPaymentGateway → PayPalPaymentGateway (registered directly)
+IPaymentGateway      → resolves to the PayPalPaymentGateway instance
+                       (IDisposable is in System and is excluded)
+```
+
+Selection **accumulates onto the implementation** rather than replacing it, so the implementation stays first among the
+services and the component stays shared. The same selector on a chain drops it:
+`Classes.From(typeof(PayPalPaymentGateway)).AsAllNonSystemInterfaces()` registers `IPaymentGateway` alone, with no
+`PayPalPaymentGateway` registration for it to share.
+
+| Method                                                                        | Service types added                                                                      |
+|-------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
+| `AsAllInterfaces()`                                                           | Every interface implemented                                                              |
+| `AsAllNonSystemInterfaces()`                                                  | Every interface except `System.*`                                                        |
+| `AsDefaultInterfaces()`                                                       | Interfaces whose name appears in the class name (`CustomerService` → `ICustomerService`) |
+| `AsDefaultNonSystemInterfaces()`                                              | Default interfaces, excluding `System.*`                                                 |
+| `AsFirstInterface()`                                                          | The first interface in metadata order                                                    |
+| `AsAllTypes()` / `AsAllNonSystemTypes()`                                      | Like the `Interfaces` variants, plus every non-abstract base class                       |
+| `AsDefaultTypes()` / `AsDefaultNonSystemTypes()`                              | Like the above, restricted to convention-matching names                                  |
+| `AsServicesFromAttribute([bool])`                                             | Service types from an `IServiceTypesProvider` attribute such as `[Services(...)]`        |
+| `AsServicesFromAttribute<TAttribute>(…)` / `AsServicesFromAttribute(Type, …)` | Service types projected from any attribute                                               |
+
+Per-method semantics are identical to the chain — see [service selectors](service-selectors.md). Selectors chain and
+accumulate here too, so `AsDefaultInterfaces().AsAllInterfaces()` registers the distinct union of both.
+
+### When nothing matches, the implementation is still registered
+
+A selector that finds no services leaves the component untouched rather than emptying it:
+
+```csharp
+services.Add(Component.From<Customer>().AsDefaultInterfaces());
+// Customer → Customer (Singleton) — Customer has no interfaces
+```
+
+The chain registers *nothing* in this situation. This is also why a component has no `AsSelf()` and no `*OrSelf`
+selectors: the implementation is seeded from the start, so "or self" is already the behavior — `AsAllInterfacesOrSelf()`
+would do exactly what `AsAllInterfaces()` does here. `AsBase()` and `AsInterface()` are absent for a different reason:
+they read the base types set by [`BasedOn`](type-filters.md), and a component has no filtering stage to set them.
+
+### Attribute selectors are validated too
+
+Attribute-selected services go through the same check as any other `As` call, so an attribute naming a service type the
+implementation isn't based on throws:
+
+```csharp
+[Contract(typeof(IProvidedServiceA))]
+public class ContractBase;  // ...but does not implement IProvidedServiceA
+
+Component.From<ContractBase>().AsServicesFromAttribute<ContractAttribute>(attribute => attribute.Contracts)
+// Throws ArgumentException:
+//   "The implementation ContractBase is not based on the service type IProvidedServiceA"
+```
+
+The chain accepts this — it registers whatever the attribute names without checking.
+
 ## Lifetime
 
 A component with no lifetime set registers as `Singleton` — the same default a [skipped lifetime stage](shared-components.md#lifetime-methods) uses. To choose another, call `AsLifetime`:
@@ -162,7 +236,7 @@ To map an open generic implementation to its interfaces, use the chain instead �
 | Scenario                                                        | Entry point                                            |
 |-----------------------------------------------------------------|--------------------------------------------------------|
 | One known type, services named explicitly                       | `Component.From(type).As<...>()`                       |
-| One known type, services chosen by convention                   | `Classes.From(type).AsInterface()`                     |
+| One known type, services chosen by convention                   | `Component.From(type).AsAllInterfaces()`               |
 | Many types matched by a convention                              | `Classes.FromThisAssembly()...`                        |
 | Several services must share one instance                        | `Component.From(type).As<...>()` — shared by default   |
 | Several services must each have their own instance              | `Classes.From(type).AsAllInterfaces()` — not shared    |

--- a/docs/registration-cheat-sheet.md
+++ b/docs/registration-cheat-sheet.md
@@ -41,7 +41,24 @@ services.Add(Component.From(typeof(PayPalPaymentGateway)).As<IPaymentGateway, ID
 // Both interfaces resolve to one shared PayPalPaymentGateway
 ```
 
-`As` throws `ArgumentException` if the implementation isn't based on a service. Open generic components can't have services added — they can't be forwarded. For more on components see [components.md](components.md).
+Services can also be picked by convention, using the same selectors as the chain — the implementation is kept and the component stays shared.
+
+| Method                                                              | Service types added                                             |
+|---------------------------------------------------------------------|------------------------------------------------------------------|
+| `AsAllInterfaces()` / `AsAllNonSystemInterfaces()`                  | Every interface, optionally excluding `System.*`                |
+| `AsDefaultInterfaces()` / `AsDefaultNonSystemInterfaces()`          | Interfaces whose name appears in the class name                 |
+| `AsFirstInterface()`                                                | The first interface in metadata order                           |
+| `AsAllTypes()` / `AsDefaultTypes()` / `…NonSystemTypes()`           | As above, plus non-abstract base classes                        |
+| `AsServicesFromAttribute(…)`                                        | Service types from a `[Services(...)]` or projected attribute    |
+
+```csharp
+services.Add(Component.From<PayPalPaymentGateway>().AsAllNonSystemInterfaces());
+// PayPalPaymentGateway + IPaymentGateway, sharing one instance
+```
+
+There is no `AsSelf()`, `AsBase()`, or `*OrSelf` on a component — the implementation is always seeded, and there is no `BasedOn` stage to supply base types.
+
+`As` throws `ArgumentException` if the implementation isn't based on a service — including services named by an attribute. When a selector matches nothing, the implementation stays registered on its own rather than dropping out. Open generic components can't have services added — they can't be forwarded. For more on components see [components.md](components.md).
 
 ## Assembly visibility
 

--- a/fixtures/Fixtures.SmallProject/Attributes/AttributeFixtures.cs
+++ b/fixtures/Fixtures.SmallProject/Attributes/AttributeFixtures.cs
@@ -193,6 +193,13 @@ public class ContractBase;
 
 public class ContractDerived : ContractBase;
 
+// Declares a contract it also implements. ContractBase deliberately does not, which makes it the case where a
+// component rejects an attribute-named service type it isn't based on.
+[Contract(typeof(IProvidedServiceA))]
+public class ContractStore : IProvidedServiceA;
+
+public class ContractStoreDerived : ContractStore;
+
 /// <summary>
 ///     Marker interface implemented by attributes that carry a <see cref="ServiceLifetime"/>. Exercises attribute
 ///     filtering by an interface the attribute implements (rather than by the concrete attribute type), including

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceComponent.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceComponent.cs
@@ -113,6 +113,21 @@ public readonly record struct ServiceComponent
     /// <exception cref="ArgumentException">If any service isn't a base type of the implementation.</exception>
     public ServiceComponent As(IEnumerable<Type> services)
     {
+        return As(_ => services);
+    }
+
+    /// <summary>
+    ///     Adds the result of calling <paramref name="serviceSelector"/> to this component. This verifies that the
+    ///     <see cref="ImplementationType"/> is assignable to each service. Duplicate services can be added; but, they
+    ///     are excluded when registering the component.
+    /// </summary>
+    /// <param name="serviceSelector">The delegate that provides services.</param>
+    /// <returns>The modified component or the same component if no services were added.</returns>
+    /// <exception cref="ArgumentException">If any service isn't a base type of the implementation.</exception>
+    public ServiceComponent As(Func<Type, IEnumerable<Type>> serviceSelector)
+    {
+        ArgumentNullException.ThrowIfNull(serviceSelector);
+        var services =  serviceSelector(this.implementation);
         ArgumentNullException.ThrowIfNull(services);
         var serviceArray = services.ToArray();
         if (serviceArray.Length == 0)

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceComponentExtensions.Attribute.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceComponentExtensions.Attribute.cs
@@ -1,0 +1,177 @@
+using System.Reflection;
+
+namespace ZCrew.Extensions.DependencyInjection.Registration;
+
+public static partial class ServiceComponentExtensions
+{
+    extension(ServiceComponent component)
+    {
+        /// <summary>
+        ///     Adds the service types returned by the <see cref="IServiceTypesProvider"/> attribute applied to the
+        ///     implementation to the component, inspecting inherited attributes. An implementation without such an
+        ///     attribute, or whose provider yields no service types, is left registered against itself alone.
+        /// </summary>
+        /// <example>
+        ///     <code>
+        ///     Component.From&lt;StripePaymentGateway&gt;().AsServicesFromAttribute()
+        ///     </code>
+        /// </example>
+        /// <returns>The modified component, or the same component if no service types were found.</returns>
+        /// <exception cref="ArgumentException">
+        ///     If the attribute names a service type the implementation isn't based on.
+        /// </exception>
+        /// <exception cref="AmbiguousMatchException">
+        ///     Thrown when the implementation has more than one <see cref="IServiceTypesProvider"/> attribute.
+        /// </exception>
+        public ServiceComponent AsServicesFromAttribute()
+        {
+            return component.AsServicesFromAttribute(true);
+        }
+
+        /// <summary>
+        ///     Adds the service types returned by the <see cref="IServiceTypesProvider"/> attribute applied to the
+        ///     implementation to the component. An implementation without such an attribute, or whose provider yields
+        ///     no service types, is left registered against itself alone.
+        /// </summary>
+        /// <param name="inherited">
+        ///     <see langword="true"/> to inspect the ancestors of the implementation type; otherwise,
+        ///     <see langword="false"/>.
+        /// </param>
+        /// <returns>The modified component, or the same component if no service types were found.</returns>
+        /// <exception cref="ArgumentException">
+        ///     If the attribute names a service type the implementation isn't based on.
+        /// </exception>
+        /// <exception cref="AmbiguousMatchException">
+        ///     Thrown when the implementation has more than one <see cref="IServiceTypesProvider"/> attribute.
+        /// </exception>
+        public ServiceComponent AsServicesFromAttribute(bool inherited)
+        {
+            return component.As(type => type.GetAttribute<IServiceTypesProvider>(inherited)?.ServiceTypes ?? []);
+        }
+
+        /// <summary>
+        ///     Adds the service types projected from a <typeparamref name="TAttribute"/> applied to the implementation
+        ///     through <paramref name="serviceSelector"/> to the component, inspecting inherited attributes. An
+        ///     implementation without the attribute, or for which the selector yields no service types, is left
+        ///     registered against itself alone.
+        /// </summary>
+        /// <param name="serviceSelector">A function that maps the matching attribute to the service types.</param>
+        /// <typeparam name="TAttribute">The attribute type or marker interface to search for.</typeparam>
+        /// <example>
+        ///     <code>
+        ///     Component.From&lt;ContractStore&gt;()
+        ///         .AsServicesFromAttribute&lt;ContractAttribute&gt;(attribute => attribute.Contracts)
+        ///     </code>
+        /// </example>
+        /// <returns>The modified component, or the same component if no service types were found.</returns>
+        /// <exception cref="ArgumentException">
+        ///     If the attribute names a service type the implementation isn't based on.
+        /// </exception>
+        /// <exception cref="AmbiguousMatchException">
+        ///     Thrown when the implementation has more than one matching <typeparamref name="TAttribute"/>.
+        /// </exception>
+        public ServiceComponent AsServicesFromAttribute<TAttribute>(
+            Func<TAttribute, IEnumerable<Type>> serviceSelector
+        )
+            where TAttribute : class
+        {
+            return component.AsServicesFromAttribute(true, serviceSelector);
+        }
+
+        /// <summary>
+        ///     Adds the service types projected from a <typeparamref name="TAttribute"/> applied to the implementation
+        ///     through <paramref name="serviceSelector"/> to the component. An implementation without the attribute, or
+        ///     for which the selector yields no service types, is left registered against itself alone.
+        /// </summary>
+        /// <param name="inherited">
+        ///     <see langword="true"/> to inspect the ancestors of the implementation type; otherwise,
+        ///     <see langword="false"/>.
+        /// </param>
+        /// <param name="serviceSelector">A function that maps the matching attribute to the service types.</param>
+        /// <typeparam name="TAttribute">The attribute type or marker interface to search for.</typeparam>
+        /// <returns>The modified component, or the same component if no service types were found.</returns>
+        /// <exception cref="ArgumentException">
+        ///     If the attribute names a service type the implementation isn't based on.
+        /// </exception>
+        /// <exception cref="AmbiguousMatchException">
+        ///     Thrown when the implementation has more than one matching <typeparamref name="TAttribute"/>.
+        /// </exception>
+        public ServiceComponent AsServicesFromAttribute<TAttribute>(
+            bool inherited,
+            Func<TAttribute, IEnumerable<Type>> serviceSelector
+        )
+            where TAttribute : class
+        {
+            ArgumentNullException.ThrowIfNull(serviceSelector);
+            return component.As(type =>
+            {
+                var attribute = type.GetAttribute<TAttribute>(inherited);
+                return attribute != null ? serviceSelector(attribute) ?? [] : [];
+            });
+        }
+
+        /// <summary>
+        ///     Adds the service types projected from an attribute assignable to <paramref name="attributeType"/>
+        ///     applied to the implementation through <paramref name="serviceSelector"/> to the component, inspecting
+        ///     inherited attributes. An implementation without a matching attribute, or for which the selector yields
+        ///     no service types, is left registered against itself alone.
+        /// </summary>
+        /// <param name="attributeType">The attribute type or marker interface to search for.</param>
+        /// <param name="serviceSelector">A function that maps the matching attribute to the service types.</param>
+        /// <example>
+        ///     <code>
+        ///     Component.From&lt;ContractStore&gt;()
+        ///         .AsServicesFromAttribute(typeof(ContractAttribute), attribute => ((ContractAttribute)attribute).Contracts)
+        ///     </code>
+        /// </example>
+        /// <returns>The modified component, or the same component if no service types were found.</returns>
+        /// <exception cref="ArgumentException">
+        ///     If the attribute names a service type the implementation isn't based on.
+        /// </exception>
+        /// <exception cref="AmbiguousMatchException">
+        ///     Thrown when the implementation has more than one attribute assignable to
+        ///     <paramref name="attributeType"/>.
+        /// </exception>
+        public ServiceComponent AsServicesFromAttribute(
+            Type attributeType,
+            Func<Attribute, IEnumerable<Type>> serviceSelector
+        )
+        {
+            return component.AsServicesFromAttribute(attributeType, true, serviceSelector);
+        }
+
+        /// <summary>
+        ///     Adds the service types projected from an attribute assignable to <paramref name="attributeType"/>
+        ///     applied to the implementation through <paramref name="serviceSelector"/> to the component. An
+        ///     implementation without a matching attribute, or for which the selector yields no service types, is left
+        ///     registered against itself alone.
+        /// </summary>
+        /// <param name="attributeType">The attribute type or marker interface to search for.</param>
+        /// <param name="inherited">
+        ///     <see langword="true"/> to inspect the ancestors of the implementation type; otherwise,
+        ///     <see langword="false"/>.
+        /// </param>
+        /// <param name="serviceSelector">A function that maps the matching attribute to the service types.</param>
+        /// <returns>The modified component, or the same component if no service types were found.</returns>
+        /// <exception cref="ArgumentException">
+        ///     If the attribute names a service type the implementation isn't based on.
+        /// </exception>
+        /// <exception cref="AmbiguousMatchException">
+        ///     Thrown when the implementation has more than one attribute assignable to
+        ///     <paramref name="attributeType"/>.
+        /// </exception>
+        public ServiceComponent AsServicesFromAttribute(
+            Type attributeType,
+            bool inherited,
+            Func<Attribute, IEnumerable<Type>> serviceSelector
+        )
+        {
+            ArgumentNullException.ThrowIfNull(serviceSelector);
+            return component.As(type =>
+            {
+                var attribute = type.GetAttribute(attributeType, inherited);
+                return attribute != null ? serviceSelector(attribute) ?? [] : [];
+            });
+        }
+    }
+}

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceComponentExtensions.Interfaces.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceComponentExtensions.Interfaces.cs
@@ -1,0 +1,103 @@
+namespace ZCrew.Extensions.DependencyInjection.Registration;
+
+public static partial class ServiceComponentExtensions
+{
+    extension(ServiceComponent component)
+    {
+        /// <summary>
+        ///     Adds every interface the implementation implements to the component.
+        /// </summary>
+        /// <example>
+        ///     Given <c>CustomerRepository : ICustomerRepository, IDisposable</c>:
+        ///     <code>
+        ///     Component.From&lt;CustomerRepository&gt;().AsAllInterfaces()
+        ///     // Registers CustomerRepository as CustomerRepository, ICustomerRepository
+        ///     // and IDisposable, all resolving to one shared instance
+        ///     </code>
+        /// </example>
+        /// <returns>The modified component, or the same component if the implementation has no interfaces.</returns>
+        public ServiceComponent AsAllInterfaces()
+        {
+            return component.As(type => type.GetInterfaces());
+        }
+
+        /// <summary>
+        ///     Adds every interface the implementation implements to the component, excluding interfaces in the
+        ///     <c>System</c> namespace and its sub-namespaces.
+        /// </summary>
+        /// <example>
+        ///     Given <c>CustomerRepository : ICustomerRepository, IDisposable</c>:
+        ///     <code>
+        ///     Component.From&lt;CustomerRepository&gt;().AsAllNonSystemInterfaces()
+        ///     // Registers CustomerRepository as CustomerRepository and ICustomerRepository
+        ///     // (IDisposable is in System and is excluded)
+        ///     </code>
+        /// </example>
+        /// <returns>The modified component, or the same component if no interfaces matched.</returns>
+        public ServiceComponent AsAllNonSystemInterfaces()
+        {
+            return component.As(type =>
+                type.GetInterfaces().Where(service => !service.IsInSameNamespaceAs<object>(includeSubnamespaces: true))
+            );
+        }
+
+        /// <summary>
+        ///     Adds the interfaces whose name matches the implementation name by convention to the component.
+        /// </summary>
+        /// <example>
+        ///     Given <c>CustomerRepository : ICustomerRepository, IDisposable</c>:
+        ///     <code>
+        ///     Component.From&lt;CustomerRepository&gt;().AsDefaultInterfaces()
+        ///     // Registers CustomerRepository as CustomerRepository and ICustomerRepository
+        ///     // ("CustomerRepository" contains "CustomerRepository" from
+        ///     // "ICustomerRepository", but not "Disposable")
+        ///     </code>
+        /// </example>
+        /// <returns>The modified component, or the same component if no interfaces matched.</returns>
+        public ServiceComponent AsDefaultInterfaces()
+        {
+            return component.As(type =>
+                type.GetInterfaces().Where(service => type.Name.Contains(service.GetInterfaceName()))
+            );
+        }
+
+        /// <summary>
+        ///     Adds the convention-matching interfaces (see <see cref="AsDefaultInterfaces"/>) to the component,
+        ///     additionally excluding interfaces in the <c>System</c> namespace and its sub-namespaces.
+        /// </summary>
+        /// <example>
+        ///     <code>
+        ///     Component.From&lt;CustomerRepository&gt;().AsDefaultNonSystemInterfaces()
+        ///     </code>
+        /// </example>
+        /// <returns>The modified component, or the same component if no interfaces matched.</returns>
+        public ServiceComponent AsDefaultNonSystemInterfaces()
+        {
+            return component.As(type =>
+                type.GetInterfaces()
+                    .Where(service => type.Name.Contains(service.GetInterfaceName()))
+                    .Where(service => !service.IsInSameNamespaceAs<object>(includeSubnamespaces: true))
+            );
+        }
+
+        /// <summary>
+        ///     Adds the first interface the implementation implements to the component.
+        /// </summary>
+        /// <example>
+        ///     Given <c>CustomerRepository : ICustomerRepository, IRepository</c>:
+        ///     <code>
+        ///     Component.From&lt;CustomerRepository&gt;().AsFirstInterface()
+        ///     // Registers CustomerRepository as CustomerRepository and ICustomerRepository
+        ///     </code>
+        /// </example>
+        /// <returns>The modified component, or the same component if the implementation has no interfaces.</returns>
+        public ServiceComponent AsFirstInterface()
+        {
+            return component.As(type =>
+            {
+                var firstInterface = type.GetInterfaces().FirstOrDefault();
+                return firstInterface != null ? [firstInterface] : [];
+            });
+        }
+    }
+}

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceComponentExtensions.Types.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceComponentExtensions.Types.cs
@@ -1,0 +1,100 @@
+namespace ZCrew.Extensions.DependencyInjection.Registration;
+
+public static partial class ServiceComponentExtensions
+{
+    extension(ServiceComponent component)
+    {
+        /// <summary>
+        ///     Adds every non-abstract class the implementation extends and every interface it implements to the
+        ///     component.
+        /// </summary>
+        /// <example>
+        ///     Given <c>CustomerRepository : AbstractRepository, ICustomerRepository, IDisposable</c>:
+        ///     <code>
+        ///     Component.From&lt;CustomerRepository&gt;().AsAllTypes()
+        ///     // Registers CustomerRepository as CustomerRepository, ICustomerRepository
+        ///     // and IDisposable
+        ///     // (AbstractRepository is abstract and is excluded)
+        ///     </code>
+        /// </example>
+        /// <returns>The modified component.</returns>
+        public ServiceComponent AsAllTypes()
+        {
+            return component.As(type => type.GetTypes().Where(service => !service.IsAbstractClass));
+        }
+
+        /// <summary>
+        ///     Adds every non-abstract class the implementation extends and every interface it implements to the
+        ///     component, excluding types in the <c>System</c> namespace and its sub-namespaces.
+        /// </summary>
+        /// <example>
+        ///     Given <c>CustomerRepository : AbstractRepository, ICustomerRepository, IDisposable</c>:
+        ///     <code>
+        ///     Component.From&lt;CustomerRepository&gt;().AsAllNonSystemTypes()
+        ///     // Registers CustomerRepository as CustomerRepository and ICustomerRepository
+        ///     // (IDisposable is in System and is excluded)
+        ///     // (AbstractRepository is abstract and is excluded)
+        ///     </code>
+        /// </example>
+        /// <returns>The modified component.</returns>
+        public ServiceComponent AsAllNonSystemTypes()
+        {
+            return component.As(type =>
+                type.GetTypes()
+                    .Where(service => !service.IsAbstractClass)
+                    .Where(service => !service.IsInSameNamespaceAs<object>(includeSubnamespaces: true))
+            );
+        }
+
+        /// <summary>
+        ///     Adds the non-abstract classes the implementation extends and the interfaces it implements whose name
+        ///     matches the implementation name by convention to the component.
+        /// </summary>
+        /// <example>
+        ///     Given <c>CustomerRepository : AbstractRepository, ICustomerRepository, IDisposable</c>:
+        ///     <code>
+        ///     Component.From&lt;CustomerRepository&gt;().AsDefaultTypes()
+        ///     // Registers CustomerRepository as CustomerRepository and ICustomerRepository
+        ///     // ("CustomerRepository" contains "CustomerRepository" from
+        ///     // "ICustomerRepository", but not "Disposable" nor "AbstractRepository")
+        ///     // (AbstractRepository is abstract and is excluded for a second reason)
+        ///     </code>
+        /// </example>
+        /// <returns>The modified component.</returns>
+        public ServiceComponent AsDefaultTypes()
+        {
+            return component.As(type =>
+                type.GetTypes()
+                    .Where(service => !service.IsAbstractClass)
+                    .Where(service => type.Name.Contains(service.GetInterfaceName()))
+            );
+        }
+
+        /// <summary>
+        ///     Adds the non-abstract classes the implementation extends and the interfaces it implements whose name
+        ///     matches the implementation name by convention to the component, excluding types in the <c>System</c>
+        ///     namespace and its sub-namespaces.
+        /// </summary>
+        /// <example>
+        ///     Given <c>CustomerRepository : AbstractRepository, ICustomerRepository, IDisposable</c>:
+        ///     <code>
+        ///     Component.From&lt;CustomerRepository&gt;().AsDefaultNonSystemTypes()
+        ///     // Registers CustomerRepository as CustomerRepository and ICustomerRepository
+        ///     // ("CustomerRepository" contains "CustomerRepository" from
+        ///     // "ICustomerRepository", but not "Disposable" nor "AbstractRepository")
+        ///     // (IDisposable is in System and is excluded for a second reason)
+        ///     // (AbstractRepository is abstract and is excluded for a second reason)
+        ///     </code>
+        /// </example>
+        /// <returns>The modified component.</returns>
+        public ServiceComponent AsDefaultNonSystemTypes()
+        {
+            return component.As(type =>
+                type.GetTypes()
+                    .Where(service => !service.IsAbstractClass)
+                    .Where(service => type.Name.Contains(service.GetInterfaceName()))
+                    .Where(service => !service.IsInSameNamespaceAs<object>(includeSubnamespaces: true))
+            );
+        }
+    }
+}

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceComponentExtensions.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceComponentExtensions.cs
@@ -3,7 +3,7 @@ namespace ZCrew.Extensions.DependencyInjection.Registration;
 /// <summary>
 ///     Extensions for the <see cref="ServiceComponent"/> type to extend existing functionality with convenient helpers.
 /// </summary>
-public static class ServiceComponentExtensions
+public static partial class ServiceComponentExtensions
 {
     extension(ServiceComponent component)
     {

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ZCrew.Extensions.DependencyInjection.Registration.csproj
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ZCrew.Extensions.DependencyInjection.Registration.csproj
@@ -23,5 +23,8 @@
     <Compile Update="TypeFilterExtensions.*.cs">
       <DependentUpon>TypeFilterExtensions.cs</DependentUpon>
     </Compile>
+    <Compile Update="ServiceComponentExtensions.*.cs">
+      <DependentUpon>ServiceComponentExtensions.cs</DependentUpon>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/SharingTests/ComponentSharingTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/SharingTests/ComponentSharingTests.cs
@@ -124,6 +124,37 @@ public class ComponentSharingTests
     }
 
     [Fact]
+    public void From_WhenServicesSelectedByConvention_ShouldShareSingleInstance()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.Add(Component.From<PayPalPaymentGateway>().AsAllNonSystemInterfaces());
+        var provider = services.BuildServiceProvider();
+
+        // Act
+        var impl = provider.GetRequiredService<PayPalPaymentGateway>();
+        var gateway = provider.GetRequiredService<IPaymentGateway>();
+
+        // Assert
+        Assert.Same(impl, gateway);
+    }
+
+    [Fact]
+    public void From_WhenOpenGenericSelectsServicesByConvention_ShouldThrowOnAdd()
+    {
+        // Arrange — selection itself is fine; forwarding an open generic is what the container cannot do.
+        var component = Component.From(typeof(InMemoryRepository<>)).AsAllInterfaces();
+        var services = new ServiceCollection();
+
+        // Act
+        Action act = () => services.Add(component);
+
+        // Assert
+        var exception = Assert.Throws<InvalidOperationException>(act);
+        Assert.Contains("Open generic services can not be forwarded", exception.Message);
+    }
+
+    [Fact]
     public void From_WhenKeyed_ShouldShareSingleInstanceAcrossKeyedServices()
     {
         // Arrange

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.UnitTests/ServiceComponentExtensionsAttributeTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.UnitTests/ServiceComponentExtensionsAttributeTests.cs
@@ -1,0 +1,229 @@
+using System.Reflection;
+using Fixtures.SmallProject.Attributes;
+
+namespace ZCrew.Extensions.DependencyInjection.Registration.UnitTests;
+
+public class ServiceComponentExtensionsAttributeTests
+{
+    [Fact]
+    public void AsServicesFromAttribute_WhenAttributeProvidesOneService_ShouldAddItAfterImplementation()
+    {
+        // Arrange
+        var component = Component.From<SingleServiceStore>();
+
+        // Act
+        var result = component.AsServicesFromAttribute();
+
+        // Assert
+        Assert.Equal([typeof(SingleServiceStore), typeof(IProvidedServiceA)], result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsServicesFromAttribute_WhenAttributeProvidesSeveralServices_ShouldAddAllInOrder()
+    {
+        // Arrange
+        var component = Component.From<MultiServiceStore>();
+
+        // Act
+        var result = component.AsServicesFromAttribute();
+
+        // Assert
+        Assert.Equal(
+            [typeof(MultiServiceStore), typeof(IProvidedServiceA), typeof(IProvidedServiceB)],
+            result.ServiceTypes
+        );
+    }
+
+    [Fact]
+    public void AsServicesFromAttribute_WhenNoAttribute_ShouldRegisterImplementationAlone()
+    {
+        // Arrange
+        var component = Component.From<UnmarkedStore>();
+
+        // Act
+        var result = component.AsServicesFromAttribute();
+
+        // Assert — the chain registers nothing here; a component always keeps its implementation.
+        Assert.Equal([typeof(UnmarkedStore)], result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsServicesFromAttribute_WhenAttributeIsInheritedAndInheritedRequested_ShouldAddProvidedServices()
+    {
+        // Arrange
+        var component = Component.From<InheritableServicesDerived>();
+
+        // Act
+        var result = component.AsServicesFromAttribute();
+
+        // Assert
+        Assert.Equal([typeof(InheritableServicesDerived), typeof(IProvidedServiceB)], result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsServicesFromAttribute_WhenInheritedIsFalse_ShouldIgnoreInheritedAttribute()
+    {
+        // Arrange
+        var component = Component.From<InheritableServicesDerived>();
+
+        // Act
+        var result = component.AsServicesFromAttribute(false);
+
+        // Assert
+        Assert.Equal([typeof(InheritableServicesDerived)], result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsServicesFromAttribute_WhenAttributeIsNotInheritable_ShouldRegisterImplementationAlone()
+    {
+        // Arrange — [Services] is declared Inherited = false, so it does not flow to the derived type.
+        var component = Component.From<ServicesDerived>();
+
+        // Act
+        var result = component.AsServicesFromAttribute();
+
+        // Assert
+        Assert.Equal([typeof(ServicesDerived)], result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsServicesFromAttribute_WhenSeveralProviderAttributes_ShouldThrow()
+    {
+        // Act
+        Action act = () => Component.From<MultiServiceProvidedStore>().AsServicesFromAttribute();
+
+        // Assert
+        Assert.Throws<AmbiguousMatchException>(act);
+    }
+
+    [Fact]
+    public void AsServicesFromAttribute_WhenAttributeNamesUnrelatedService_ShouldThrow()
+    {
+        // Act — ContractBase declares a contract it does not implement. The chain accepts this unchecked; a
+        // component validates eagerly.
+        Action act = () =>
+            Component.From<ContractBase>().AsServicesFromAttribute<ContractAttribute>(attribute => attribute.Contracts);
+
+        // Assert
+        var exception = Assert.Throws<ArgumentException>(act);
+        Assert.Contains("is not based on the service type", exception.Message);
+    }
+
+    [Fact]
+    public void AsServicesFromAttribute_T_WhenAttributeProjectsServices_ShouldAddThem()
+    {
+        // Arrange
+        var component = Component.From<ContractStore>();
+
+        // Act
+        var result = component.AsServicesFromAttribute<ContractAttribute>(attribute => attribute.Contracts);
+
+        // Assert
+        Assert.Equal([typeof(ContractStore), typeof(IProvidedServiceA)], result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsServicesFromAttribute_T_WhenInheritedIsFalse_ShouldIgnoreInheritedAttribute()
+    {
+        // Arrange
+        var component = Component.From<ContractStoreDerived>();
+
+        // Act
+        var result = component.AsServicesFromAttribute<ContractAttribute>(false, attribute => attribute.Contracts);
+
+        // Assert
+        Assert.Equal([typeof(ContractStoreDerived)], result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsServicesFromAttribute_T_WhenInheritedRequested_ShouldProjectInheritedAttribute()
+    {
+        // Arrange
+        var component = Component.From<ContractStoreDerived>();
+
+        // Act
+        var result = component.AsServicesFromAttribute<ContractAttribute>(attribute => attribute.Contracts);
+
+        // Assert
+        Assert.Equal([typeof(ContractStoreDerived), typeof(IProvidedServiceA)], result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsServicesFromAttribute_T_WhenNoAttribute_ShouldRegisterImplementationAlone()
+    {
+        // Arrange
+        var component = Component.From<UnmarkedStore>();
+
+        // Act
+        var result = component.AsServicesFromAttribute<ContractAttribute>(attribute => attribute.Contracts);
+
+        // Assert
+        Assert.Equal([typeof(UnmarkedStore)], result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsServicesFromAttribute_T_WhenServiceSelectorIsNull_ShouldThrow()
+    {
+        // Act
+        Action act = () => Component.From<ContractStore>().AsServicesFromAttribute<ContractAttribute>(null!);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(act);
+    }
+
+    [Fact]
+    public void AsServicesFromAttribute_WithAttributeType_WhenAttributeProjectsServices_ShouldAddThem()
+    {
+        // Arrange
+        var component = Component.From<ContractStore>();
+
+        // Act
+        var result = component.AsServicesFromAttribute(
+            typeof(ContractAttribute),
+            attribute => ((ContractAttribute)attribute).Contracts
+        );
+
+        // Assert
+        Assert.Equal([typeof(ContractStore), typeof(IProvidedServiceA)], result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsServicesFromAttribute_WithAttributeType_WhenInheritedIsFalse_ShouldIgnoreInheritedAttribute()
+    {
+        // Arrange
+        var component = Component.From<ContractStoreDerived>();
+
+        // Act
+        var result = component.AsServicesFromAttribute(
+            typeof(ContractAttribute),
+            false,
+            attribute => ((ContractAttribute)attribute).Contracts
+        );
+
+        // Assert
+        Assert.Equal([typeof(ContractStoreDerived)], result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsServicesFromAttribute_WithAttributeType_WhenServiceSelectorIsNull_ShouldThrow()
+    {
+        // Act
+        Action act = () => Component.From<ContractStore>().AsServicesFromAttribute(typeof(ContractAttribute), null!);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(act);
+    }
+
+    [Fact]
+    public void AsServicesFromAttribute_WhenCalled_ShouldNotChangeImplementationType()
+    {
+        // Arrange
+        var component = Component.From<SingleServiceStore>();
+
+        // Act
+        var result = component.AsServicesFromAttribute();
+
+        // Assert
+        Assert.Equal(typeof(SingleServiceStore), result.ImplementationType);
+    }
+}

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.UnitTests/ServiceComponentExtensionsInterfaceTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.UnitTests/ServiceComponentExtensionsInterfaceTests.cs
@@ -1,0 +1,163 @@
+using Fixtures.SmallProject.Application.Ports;
+using Fixtures.SmallProject.Application.Services;
+using Fixtures.SmallProject.Domain.Entities;
+using Fixtures.SmallProject.Domain.ValueObjects;
+using Fixtures.SmallProject.Infrastructure.External;
+
+namespace ZCrew.Extensions.DependencyInjection.Registration.UnitTests;
+
+public class ServiceComponentExtensionsInterfaceTests
+{
+    [Fact]
+    public void AsAllInterfaces_WhenCalled_ShouldKeepImplementationFirstThenAddInterfaces()
+    {
+        // Arrange
+        var component = Component.From<PayPalPaymentGateway>();
+
+        // Act
+        var result = component.AsAllInterfaces();
+
+        // Assert — a component is seeded with its implementation, so selection accumulates onto it rather than
+        // replacing it the way the Classes chain does.
+        Assert.Equal(typeof(PayPalPaymentGateway), result.ServiceTypes[0]);
+        Assert.Contains(typeof(IPaymentGateway), result.ServiceTypes);
+        Assert.Contains(typeof(IDisposable), result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsAllInterfaces_WhenNoInterfaces_ShouldRegisterImplementationAlone()
+    {
+        // Arrange
+        var component = Component.From<Customer>();
+
+        // Act
+        var result = component.AsAllInterfaces();
+
+        // Assert — the chain registers nothing here; a component always keeps its implementation.
+        Assert.Equal([typeof(Customer)], result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsAllNonSystemInterfaces_WhenCalled_ShouldExcludeSystemInterfaces()
+    {
+        // Arrange
+        var component = Component.From<PayPalPaymentGateway>();
+
+        // Act
+        var result = component.AsAllNonSystemInterfaces();
+
+        // Assert
+        Assert.Equal([typeof(PayPalPaymentGateway), typeof(IPaymentGateway)], result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsAllNonSystemInterfaces_WhenOnlySystemInterfaces_ShouldRegisterImplementationAlone()
+    {
+        // Arrange
+        var component = Component.From<Address>();
+
+        // Act
+        var result = component.AsAllNonSystemInterfaces();
+
+        // Assert
+        Assert.Equal([typeof(Address)], result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsDefaultInterfaces_WhenCalled_ShouldMatchByNamingConvention()
+    {
+        // Arrange
+        var component = Component.From<CustomerService>();
+
+        // Act
+        var result = component.AsDefaultInterfaces();
+
+        // Assert
+        Assert.Equal([typeof(CustomerService), typeof(ICustomerService)], result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsDefaultInterfaces_WhenNoConventionMatch_ShouldRegisterImplementationAlone()
+    {
+        // Arrange
+        var component = Component.From<LegacyOrderProcessor>();
+
+        // Act
+        var result = component.AsDefaultInterfaces();
+
+        // Assert
+        Assert.Equal([typeof(LegacyOrderProcessor)], result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsDefaultNonSystemInterfaces_WhenCalled_ShouldCombineBothFilters()
+    {
+        // Arrange
+        var component = Component.From<PayPalPaymentGateway>();
+
+        // Act
+        var result = component.AsDefaultNonSystemInterfaces();
+
+        // Assert
+        Assert.Equal([typeof(PayPalPaymentGateway), typeof(IPaymentGateway)], result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsFirstInterface_WhenCalled_ShouldAddFirstInterface()
+    {
+        // Arrange
+        var component = Component.From<CustomerService>();
+
+        // Act
+        var result = component.AsFirstInterface();
+
+        // Assert
+        Assert.Equal(2, result.ServiceTypes.Count);
+        Assert.Equal(typeof(CustomerService), result.ServiceTypes[0]);
+        Assert.Contains(result.ServiceTypes[1], typeof(CustomerService).GetInterfaces());
+    }
+
+    [Fact]
+    public void AsFirstInterface_WhenNoInterfaces_ShouldRegisterImplementationAlone()
+    {
+        // Arrange
+        var component = Component.From<Customer>();
+
+        // Act
+        var result = component.AsFirstInterface();
+
+        // Assert
+        Assert.Equal([typeof(Customer)], result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsAllInterfaces_WhenChainedWithAsDefaultInterfaces_ShouldAccumulateInFirstOccurrenceOrder()
+    {
+        // Arrange
+        var component = Component.From<PayPalPaymentGateway>();
+
+        // Act
+        var result = component.AsDefaultInterfaces().AsAllInterfaces();
+
+        // Assert — the implementation then the convention match lead; AsAllInterfaces appends the rest in
+        // reflection order. Duplicates are kept on the component and collapsed when it is registered.
+        Assert.Equal(typeof(PayPalPaymentGateway), result.ServiceTypes[0]);
+        Assert.Equal(typeof(IPaymentGateway), result.ServiceTypes[1]);
+        Assert.Equal(4, result.ServiceTypes.Count);
+        Assert.Equal(2, result.ServiceTypes.Count(service => service == typeof(IPaymentGateway)));
+        Assert.Contains(typeof(IDisposable), result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsAllInterfaces_WhenCalled_ShouldNotChangeImplementationType()
+    {
+        // Arrange
+        var component = Component.From<PayPalPaymentGateway>();
+
+        // Act
+        var result = component.AsAllInterfaces();
+
+        // Assert
+        Assert.Equal(typeof(PayPalPaymentGateway), result.ImplementationType);
+    }
+}

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.UnitTests/ServiceComponentExtensionsTypeTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.UnitTests/ServiceComponentExtensionsTypeTests.cs
@@ -1,0 +1,145 @@
+using Fixtures.SmallProject.Application.Ports;
+using Fixtures.SmallProject.Application.Services;
+using Fixtures.SmallProject.Domain.Entities;
+using Fixtures.SmallProject.Domain.Repositories;
+using Fixtures.SmallProject.Infrastructure.External;
+using Fixtures.SmallProject.Infrastructure.Persistence;
+
+namespace ZCrew.Extensions.DependencyInjection.Registration.UnitTests;
+
+public class ServiceComponentExtensionsTypeTests
+{
+    [Fact]
+    public void AsAllTypes_WhenCalled_ShouldAddNonAbstractBaseClassesAndInterfaces()
+    {
+        // Arrange
+        var component = Component.From<SqlCustomerRepository>();
+
+        // Act
+        var result = component.AsAllTypes();
+
+        // Assert
+        Assert.Equal(typeof(SqlCustomerRepository), result.ServiceTypes[0]);
+        Assert.Contains(typeof(ICustomerRepository), result.ServiceTypes);
+        Assert.Contains(typeof(IRepository<Customer>), result.ServiceTypes);
+        Assert.Contains(typeof(IDisposable), result.ServiceTypes);
+        Assert.DoesNotContain(typeof(RepositoryBase<Customer>), result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsAllTypes_WhenCalled_ShouldRepeatTheSeededImplementation()
+    {
+        // Arrange
+        var component = Component.From<SqlCustomerRepository>();
+
+        // Act
+        var result = component.AsAllTypes();
+
+        // Assert — GetTypes() yields the implementation first, which the component already carries. The duplicate is
+        // collapsed when the component is registered.
+        Assert.Equal(2, result.ServiceTypes.Count(service => service == typeof(SqlCustomerRepository)));
+    }
+
+    [Fact]
+    public void AsAllNonSystemTypes_WhenCalled_ShouldExcludeSystemTypesAndAbstractBaseClasses()
+    {
+        // Arrange
+        var component = Component.From<SqlCustomerRepository>();
+
+        // Act
+        var result = component.AsAllNonSystemTypes();
+
+        // Assert
+        Assert.Contains(typeof(ICustomerRepository), result.ServiceTypes);
+        Assert.DoesNotContain(typeof(IDisposable), result.ServiceTypes);
+        Assert.DoesNotContain(typeof(IAsyncDisposable), result.ServiceTypes);
+        Assert.DoesNotContain(typeof(object), result.ServiceTypes);
+        Assert.DoesNotContain(typeof(RepositoryBase<Customer>), result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsAllTypes_WhenTypeExtendsConcreteBase_ShouldAddBaseAndInheritedInterfaces()
+    {
+        // Arrange
+        var component = Component.From<CachingPayPalPaymentGateway>();
+
+        // Act
+        var result = component.AsAllTypes();
+
+        // Assert
+        Assert.Contains(typeof(PayPalPaymentGateway), result.ServiceTypes);
+        Assert.Contains(typeof(IPaymentGateway), result.ServiceTypes);
+        Assert.Contains(typeof(IDisposable), result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsDefaultTypes_WhenCalled_ShouldMatchByNamingConvention()
+    {
+        // Arrange
+        var component = Component.From<CustomerService>();
+
+        // Act
+        var result = component.AsDefaultTypes();
+
+        // Assert
+        Assert.Contains(typeof(ICustomerService), result.ServiceTypes);
+        Assert.DoesNotContain(typeof(object), result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsDefaultTypes_WhenNoConventionMatch_ShouldRegisterImplementationAlone()
+    {
+        // Arrange
+        var component = Component.From<Customer>();
+
+        // Act
+        var result = component.AsDefaultTypes();
+
+        // Assert — GetTypes() still yields Customer itself, which matches its own name by convention.
+        Assert.Equal([typeof(Customer), typeof(Customer)], result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsDefaultNonSystemTypes_WhenCalled_ShouldCombineBothFilters()
+    {
+        // Arrange
+        var component = Component.From<SqlCustomerRepository>();
+
+        // Act
+        var result = component.AsDefaultNonSystemTypes();
+
+        // Assert
+        Assert.Contains(typeof(ICustomerRepository), result.ServiceTypes);
+        Assert.DoesNotContain(typeof(IDisposable), result.ServiceTypes);
+        Assert.DoesNotContain(typeof(IAsyncDisposable), result.ServiceTypes);
+        Assert.DoesNotContain(typeof(RepositoryBase<Customer>), result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsDefaultNonSystemTypes_WhenBaseClassNameMatchesConvention_ShouldAddBase()
+    {
+        // Arrange
+        var component = Component.From<CachingPayPalPaymentGateway>();
+
+        // Act
+        var result = component.AsDefaultNonSystemTypes();
+
+        // Assert
+        Assert.Contains(typeof(PayPalPaymentGateway), result.ServiceTypes);
+        Assert.Contains(typeof(IPaymentGateway), result.ServiceTypes);
+        Assert.DoesNotContain(typeof(IDisposable), result.ServiceTypes);
+    }
+
+    [Fact]
+    public void AsAllTypes_WhenCalled_ShouldNotChangeImplementationType()
+    {
+        // Arrange
+        var component = Component.From<SqlCustomerRepository>();
+
+        // Act
+        var result = component.AsAllTypes();
+
+        // Assert
+        Assert.Equal(typeof(SqlCustomerRepository), result.ImplementationType);
+    }
+}


### PR DESCRIPTION
Adds in component extensions to match the `ServiceSelector` API - `AsAllInterfaces()`, `AsAllTypes()`, etc. 

This will make it easier to register multiple services; registering every service through the non-scanning extensions was also error-prone.

Closes #61