### PR TITLE
#70 - Add in AOT support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,17 @@ The `fixtures/` directory contains projects that mirror real-world code for inte
   - `Infrastructure/` — Repository implementations (`SqlCustomerRepository`, `InMemoryRepository<T>`), external integrations (`StripePaymentGateway`), notification senders
   - Includes internal types, nested classes, static classes, and generic types for thorough visibility and type-filtering test coverage
 
+## Trimming / Native AOT
+
+Both library projects set `<IsAotCompatible>true</IsAotCompatible>` (in the csprojs, **not** `src/Directory.Build.props` — the `netstandard2.0` Generator project imports that file and the property is invalid below net7). This turns on the trim/AOT analyzers, so **the build must stay at zero IL2xxx/IL3xxx warnings**.
+
+Two paths, treated differently on purpose:
+
+- **Trim-safe — annotate.** The `[Service]` generator path, `Service.From`, and the decorator API. `Service` carries a private `ImplementationMembers` constant (`PublicConstructors | Interfaces`) applied to the `implementation` field, every constructor, `ImplementationType`, and the `From` factories; `PublicConstructors` satisfies `ServiceDescriptor`, `Interfaces` satisfies the `As*` selectors and `ServiceFilter`. In `TypeExtensions`, the members that call `GetInterfaces()` live in a **second `extension(...)` block** with an annotated receiver so the namespace helpers aren't over-constrained.
+- **Not trim-safe — `[RequiresUnreferencedCode]` at the entry, suppress inside.** Assembly scanning can't survive trimming. Every `Classes`/`Types` entry point is RUC (message in `Classes.RequiresUnreferencedCodeMessage`); the chain types (`AssemblyTypeSelector`, `TypeFilter`, `ServiceSelector`, `ServiceSelectorExtensions`) carry **type-level** `[UnconditionalSuppressMessage]` with `ScanPath.Justification`, since their internal constructors make them reachable only from those entries. This yields one warning per chain instead of one per stage.
+
+Gotchas: a lambda that calls a DAM-annotated method becomes a delegate the trimmer can't follow (IL2111) — use an explicit loop. Interface-selector helpers must hoist `GetInterfaces()` onto `service.ImplementationType` **outside** the lambda, because annotations don't flow through `Func<Type, …>`. Open generics still warn inside MSDI (`MakeGenericType`); that's a container limitation, not ours.
+
 ## Code Conventions
 
 - **Formatting:** CSharpier (auto-runs via pre-commit hook). Run `dotnet tool run CSharpier format .` to format manually.

--- a/docs/source-generator.md
+++ b/docs/source-generator.md
@@ -113,12 +113,12 @@ types **and** the `Services.FromThisAssembly()` call site must live in the same 
 
 The `ServiceRegistrationAnalyzer` reports misuse of the attribute family. All rules are errors.
 
-| Rule       | Reported when…                                                                                                        |
-|------------|-----------------------------------------------------------------------------------------------------------------------|
-| `ZCDI001`  | A `[Keyed]` or `[As]` key is an array. Arrays compare by reference, so a fresh array never matches a lookup - use a value-equatable key (string, enum, primitive). |
-| `ZCDI002`  | A modifier attribute (`[As]`, `[Singleton]`/`[Scoped]`/`[Transient]`, `[Keyed]`) is used on a type with no `[Service]`; the modifier has no effect. |
-| `ZCDI003`  | An `[As]` service type is one the implementation is not assignable to. (`As<T>` is intentionally unconstrained, so this analyzer enforces assignability instead.) |
-| `ZCDI004`  | A type carries more than one of `[Singleton]`, `[Scoped]`, `[Transient]`.                                             |
+| Rule      | Reported when…                                                                                                                                                     |
+|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ZCDI001` | A `[Keyed]` or `[As]` key is an array. Arrays compare by reference, so a fresh array never matches a lookup - use a value-equatable key (string, enum, primitive). |
+| `ZCDI002` | A modifier attribute (`[As]`, `[Singleton]`/`[Scoped]`/`[Transient]`, `[Keyed]`) is used on a type with no `[Service]`; the modifier has no effect.                |
+| `ZCDI003` | An `[As]` service type is one the implementation is not assignable to. (`As<T>` is intentionally unconstrained, so this analyzer enforces assignability instead.)  |
+| `ZCDI004` | A type carries more than one of `[Singleton]`, `[Scoped]`, `[Transient]`.                                                                                          |
 
 ```csharp
 [Service, Keyed(new[] { 1, 2 })]   // ZCDI001: use a value-equatable key
@@ -142,3 +142,18 @@ public class TwoLifetimes;
 | `Classes` / `Types` scan     | You want convention-based bulk registration (by base type, namespace, naming) at startup. |
 
 Both share the same runtime `Service`/`ServiceDescriptor` machinery, so their registrations behave identically.
+
+## Trimming and Native AOT
+
+This is the trim-safe registration path, and the reason to prefer it when publishing trimmed or AOT. The generated
+`Service.From(typeof(Impl), …)` calls reference each implementation as a `typeof` literal, and `Service` annotates the
+implementation with `[DynamicallyAccessedMembers]` for public constructors (so `ServiceDescriptor` can still activate
+it) and interfaces (so the `As*` selectors and `ServiceFilter` still see the hierarchy). Nothing is discovered at
+startup, so there is nothing for the trimmer to remove out from under you.
+
+The reflection-based `Classes`/`Types` scan is the opposite case: its entry points are annotated
+`[RequiresUnreferencedCode]` and produce one `IL2026` per chain, because the trimmer removes unreferenced types before
+the scan can see them.
+
+The remaining unavoidable gap is **open generic** service types, which the Microsoft container resolves via
+`MakeGenericType`; that is a container limitation rather than something this package can annotate away.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,6 +11,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <IsPackable>true</IsPackable>
+    <WarningsAsErrors>$(WarningsAsErrors);IL2026;IL2067;IL2070;IL2072;IL2075;IL2077;IL2111;IL3050</WarningsAsErrors>
   </PropertyGroup>
 
   <!-- Common projects for all library projects -->

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/Aot.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/Aot.cs
@@ -1,0 +1,18 @@
+namespace ZCrew.Extensions.DependencyInjection.Registration;
+
+/// <summary>
+///     The shared trimmer-suppression justification for the reflection-based <see cref="Classes"/>/<see cref="Types"/>
+///     registration chain.
+/// </summary>
+internal static class Aot
+{
+    /// <summary>
+    ///     Every stage of the chain has internal constructors, so a chain can only start at a <see cref="Classes"/> or
+    ///     <see cref="Types"/> entry point. Those are all annotated with
+    ///     <see cref="System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute"/>, so the caller is warned
+    ///     once for the whole chain instead of once per stage.
+    /// </summary>
+    internal const string Justification =
+        "Every stage of the registration chain has internal constructors, so it is only reachable from the "
+        + "RequiresUnreferencedCode entry points on Classes/Types. Those warn the caller once for the whole chain.";
+}

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/AssemblyTypeSelector.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/AssemblyTypeSelector.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace ZCrew.Extensions.DependencyInjection.Registration;
@@ -8,6 +9,11 @@ namespace ZCrew.Extensions.DependencyInjection.Registration;
 ///     <see cref="IncludeInternalTypes"/> or <see cref="IncludeAllTypes"/> to broaden the scope. The assembly is not
 ///     scanned until the chain is terminated.
 /// </summary>
+[UnconditionalSuppressMessage(
+    "Trimming",
+    "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
+    Justification = Aot.Justification
+)]
 public sealed class AssemblyTypeSelector : TypeFilter
 {
     private readonly Assembly assembly;

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/Classes.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/Classes.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -7,12 +8,21 @@ namespace ZCrew.Extensions.DependencyInjection.Registration;
 ///     Entry point for convention-based registration of concrete, non-abstract classes. Provides static factory
 ///     methods to begin a registration chain from an assembly or a collection of types, filtering to classes only.
 /// </summary>
+/// <remarks>
+///     This API is not compatible with trimming or native AOT. Use the <c>[Service]</c> source generator
+///     (<c>Services.FromThisAssembly()</c>) or <see cref="Service.From(Type)"/> instead.
+/// </remarks>
 public static class Classes
 {
+    internal const string RequiresUnreferencedCodeMessage =
+        "Convention-based registration inspects types reflectively and cannot be made trim-safe. Use the [Service] "
+        + "source generator (Services.FromThisAssembly()) or Service.From for trim-compatible registration.";
+
     /// <summary>
     ///     Begins registration from the specified collection of types, filtering to concrete, non-abstract classes.
     /// </summary>
     /// <param name="types">The types to select from.</param>
+    [RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
     public static TypeFilter From(IEnumerable<Type> types)
     {
         ArgumentNullException.ThrowIfNull(types);
@@ -23,6 +33,7 @@ public static class Classes
     ///     Begins registration from the specified types, filtering to concrete, non-abstract classes.
     /// </summary>
     /// <param name="types">The types to select from.</param>
+    [RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
     public static TypeFilter From(params Type[] types)
     {
         ArgumentNullException.ThrowIfNull(types);
@@ -33,6 +44,7 @@ public static class Classes
     ///     Begins registration by scanning the specified assembly for concrete, non-abstract classes.
     /// </summary>
     /// <param name="assembly">The assembly to scan.</param>
+    [RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
     public static AssemblyTypeSelector FromAssembly(Assembly assembly)
     {
         ArgumentNullException.ThrowIfNull(assembly);
@@ -44,6 +56,7 @@ public static class Classes
     ///     classes.
     /// </summary>
     /// <param name="type">A type whose containing assembly will be scanned.</param>
+    [RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
     public static AssemblyTypeSelector FromAssemblyContaining(Type type)
     {
         ArgumentNullException.ThrowIfNull(type);
@@ -55,6 +68,7 @@ public static class Classes
     ///     classes.
     /// </summary>
     /// <typeparam name="T">A type whose containing assembly will be scanned.</typeparam>
+    [RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
     public static AssemblyTypeSelector FromAssemblyContaining<T>()
     {
         return FromAssemblyContaining(typeof(T));
@@ -63,6 +77,7 @@ public static class Classes
     /// <summary>
     ///     Begins registration by scanning the calling assembly for concrete, non-abstract classes.
     /// </summary>
+    [RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static AssemblyTypeSelector FromThisAssembly()
     {

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/README.md
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/README.md
@@ -118,6 +118,23 @@ services.Add(Services.FromThisAssembly().BasedOn<IEmailSender>());  // or narrow
 See **[Compile-Time Registration with `[Service]`](https://github.com/ZCrewSoftware/ZCrew.Extensions.DependencyInjection/blob/main/docs/source-generator.md)** for the full attribute model
 (`[As<T>]`, `[Singleton]`/`[Scoped]`/`[Transient]`, `[Keyed]`), semantics, and the `ZCDI001`–`ZCDI004` diagnostics.
 
+## Trimming and Native AOT
+
+The package is marked `IsAotCompatible`, but only the compile-time path is trim-safe:
+
+| Path                                            | Trimming / AOT                                                         |
+|-------------------------------------------------|------------------------------------------------------------------------|
+| `[Service]` + `Services.FromThisAssembly()`     | ✅ Safe: the registrations are baked in at compile time.                |
+| `Service.From<T>()` / `Service.From(typeof(T))` | ✅ Safe: the implementation type keeps its constructors and interfaces. |
+| `Classes` / `Types` assembly scanning           | ⚠️ Not supported: the entry points are `[RequiresUnreferencedCode]`.   |
+
+Assembly scanning cannot be made trim-safe: the trimmer removes unreferenced types *before* the scan runs, so types
+would silently disappear from the container. Rather than fail at runtime, every `Classes`/`Types` entry point warns at
+compile time (one `IL2026` per chain) and points you at the generator. If you publish trimmed or AOT, use `[Service]`.
+
+> One caveat that is outside this package's control: registering **open generic** service types uses
+> `MakeGenericType`, which Microsoft's container cannot make AOT-safe.
+
 ## Full API reference
 
 The summaries above cover the common cases. For a complete one-page reference covering every method, overload, and recipe, see the **[Registration Cheat Sheet](https://github.com/ZCrewSoftware/ZCrew.Extensions.DependencyInjection/blob/main/docs/registration-cheat-sheet.md)**. For deeper narrative guides see the [docs folder](https://github.com/ZCrewSoftware/ZCrew.Extensions.DependencyInjection/tree/main/docs).

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/Service.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/Service.cs
@@ -13,6 +13,10 @@ namespace ZCrew.Extensions.DependencyInjection.Registration;
 /// </summary>
 public readonly record struct Service
 {
+    private const DynamicallyAccessedMemberTypes ImplementationMembers =
+        DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.Interfaces;
+
+    [DynamicallyAccessedMembers(ImplementationMembers)]
     private readonly Type implementation;
     private readonly IReadOnlyList<Type> services;
     private readonly IReadOnlyList<KeyValuePair<Type, object?>>? keyedServices;
@@ -27,7 +31,7 @@ public readonly record struct Service
     ///     are added on top of it, so they resolve to a single shared instance.
     /// </summary>
     /// <param name="implementation">The implementation type.</param>
-    internal Service(Type implementation)
+    internal Service([DynamicallyAccessedMembers(ImplementationMembers)] Type implementation)
     {
         this.implementation = implementation;
         this.services = [implementation];
@@ -38,7 +42,10 @@ public readonly record struct Service
     /// </summary>
     /// <param name="implementation">The implementation type.</param>
     /// <param name="services">The services to register for the <paramref name="implementation"/>.</param>
-    internal Service(Type implementation, IReadOnlyList<Type> services)
+    internal Service(
+        [DynamicallyAccessedMembers(ImplementationMembers)] Type implementation,
+        IReadOnlyList<Type> services
+    )
     {
         this.implementation = implementation;
         this.services = services;
@@ -58,7 +65,7 @@ public readonly record struct Service
     ///     analyzers already handled them.
     /// </remarks>
     private Service(
-        Type implementation,
+        [DynamicallyAccessedMembers(ImplementationMembers)] Type implementation,
         ServiceLifetime lifetime,
         object? key,
         (Type ServiceType, object? Key)[] serviceTypes
@@ -92,7 +99,7 @@ public readonly record struct Service
     /// <param name="serviceKeyProvider">The dynamic service key provider.</param>
     /// <param name="keyedServices">The additional service types with their per-type keys.</param>
     private Service(
-        Type implementation,
+        [DynamicallyAccessedMembers(ImplementationMembers)] Type implementation,
         IReadOnlyList<Type> services,
         ServiceLifetime? lifetime,
         Func<Type, ServiceLifetime>? lifetimeProvider,
@@ -115,9 +122,7 @@ public readonly record struct Service
     ///     <paramref name="type"/> itself; services added with <c>As</c> are forwarded to it.
     /// </summary>
     /// <param name="type">The implementation type to build a registration from.</param>
-    public static Service From(
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type
-    )
+    public static Service From([DynamicallyAccessedMembers(ImplementationMembers)] Type type)
     {
         return new Service(type);
     }
@@ -127,9 +132,7 @@ public readonly record struct Service
     ///     against the type itself; services added with <c>As</c> are forwarded to it.
     /// </summary>
     /// <typeparam name="T">The implementation type to build a registration from.</typeparam>
-    public static Service From<
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T
-    >()
+    public static Service From<[DynamicallyAccessedMembers(ImplementationMembers)] T>()
     {
         return new Service(typeof(T));
     }
@@ -154,7 +157,7 @@ public readonly record struct Service
     /// <param name="serviceTypes">The additional service types with their per-type keys.</param>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static Service From(
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementation,
+        [DynamicallyAccessedMembers(ImplementationMembers)] Type implementation,
         ServiceLifetime lifetime,
         object? key,
         params (Type ServiceType, object? Key)[] serviceTypes
@@ -166,6 +169,7 @@ public readonly record struct Service
     /// <summary>
     ///     The implementation type.
     /// </summary>
+    [DynamicallyAccessedMembers(ImplementationMembers)]
     public Type ImplementationType => this.implementation;
 
     /// <summary>

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceExtensions.Interfaces.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceExtensions.Interfaces.cs
@@ -18,7 +18,7 @@ public static partial class ServiceExtensions
         /// <returns>The modified service, or the same service if the implementation has no interfaces.</returns>
         public Service AsAllInterfaces()
         {
-            return service.As(type => type.GetInterfaces());
+            return service.As(service.ImplementationType.GetInterfaces());
         }
 
         /// <summary>
@@ -36,8 +36,10 @@ public static partial class ServiceExtensions
         /// <returns>The modified service, or the same service if no interfaces matched.</returns>
         public Service AsAllNonSystemInterfaces()
         {
-            return service.As(type =>
-                type.GetInterfaces().Where(service => !service.IsInSameNamespaceAs<object>(includeSubnamespaces: true))
+            return service.As(
+                service
+                    .ImplementationType.GetInterfaces()
+                    .Where(candidate => !candidate.IsInSameNamespaceAs<object>(includeSubnamespaces: true))
             );
         }
 
@@ -56,8 +58,9 @@ public static partial class ServiceExtensions
         /// <returns>The modified service, or the same service if no interfaces matched.</returns>
         public Service AsDefaultInterfaces()
         {
-            return service.As(type =>
-                type.GetInterfaces().Where(service => type.Name.Contains(service.GetInterfaceName()))
+            var implementation = service.ImplementationType;
+            return service.As(
+                implementation.GetInterfaces().Where(candidate => implementation.Name.Contains(candidate.GetInterfaceName()))
             );
         }
 
@@ -73,10 +76,12 @@ public static partial class ServiceExtensions
         /// <returns>The modified service, or the same service if no interfaces matched.</returns>
         public Service AsDefaultNonSystemInterfaces()
         {
-            return service.As(type =>
-                type.GetInterfaces()
-                    .Where(service => type.Name.Contains(service.GetInterfaceName()))
-                    .Where(service => !service.IsInSameNamespaceAs<object>(includeSubnamespaces: true))
+            var implementation = service.ImplementationType;
+            return service.As(
+                implementation
+                    .GetInterfaces()
+                    .Where(candidate => implementation.Name.Contains(candidate.GetInterfaceName()))
+                    .Where(candidate => !candidate.IsInSameNamespaceAs<object>(includeSubnamespaces: true))
             );
         }
 
@@ -93,11 +98,9 @@ public static partial class ServiceExtensions
         /// <returns>The modified service, or the same service if the implementation has no interfaces.</returns>
         public Service AsFirstInterface()
         {
-            return service.As(type =>
-            {
-                var firstInterface = type.GetInterfaces().FirstOrDefault();
-                return firstInterface != null ? [firstInterface] : [];
-            });
+            var firstInterface = service.ImplementationType.GetInterfaces().FirstOrDefault();
+            Type[] services = firstInterface != null ? [firstInterface] : [];
+            return service.As(services);
         }
     }
 }

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceExtensions.Types.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceExtensions.Types.cs
@@ -20,7 +20,7 @@ public static partial class ServiceExtensions
         /// <returns>The modified service.</returns>
         public Service AsAllTypes()
         {
-            return service.As(type => type.GetTypes().Where(service => !service.IsAbstractClass));
+            return service.As(service.ImplementationType.GetTypes().Where(candidate => !candidate.IsAbstractClass));
         }
 
         /// <summary>
@@ -39,10 +39,11 @@ public static partial class ServiceExtensions
         /// <returns>The modified service.</returns>
         public Service AsAllNonSystemTypes()
         {
-            return service.As(type =>
-                type.GetTypes()
-                    .Where(service => !service.IsAbstractClass)
-                    .Where(service => !service.IsInSameNamespaceAs<object>(includeSubnamespaces: true))
+            return service.As(
+                service
+                    .ImplementationType.GetTypes()
+                    .Where(candidate => !candidate.IsAbstractClass)
+                    .Where(candidate => !candidate.IsInSameNamespaceAs<object>(includeSubnamespaces: true))
             );
         }
 
@@ -63,10 +64,12 @@ public static partial class ServiceExtensions
         /// <returns>The modified service.</returns>
         public Service AsDefaultTypes()
         {
-            return service.As(type =>
-                type.GetTypes()
-                    .Where(service => !service.IsAbstractClass)
-                    .Where(service => type.Name.Contains(service.GetInterfaceName()))
+            var implementation = service.ImplementationType;
+            return service.As(
+                implementation
+                    .GetTypes()
+                    .Where(candidate => !candidate.IsAbstractClass)
+                    .Where(candidate => implementation.Name.Contains(candidate.GetInterfaceName()))
             );
         }
 
@@ -89,11 +92,13 @@ public static partial class ServiceExtensions
         /// <returns>The modified service.</returns>
         public Service AsDefaultNonSystemTypes()
         {
-            return service.As(type =>
-                type.GetTypes()
-                    .Where(service => !service.IsAbstractClass)
-                    .Where(service => type.Name.Contains(service.GetInterfaceName()))
-                    .Where(service => !service.IsInSameNamespaceAs<object>(includeSubnamespaces: true))
+            var implementation = service.ImplementationType;
+            return service.As(
+                implementation
+                    .GetTypes()
+                    .Where(candidate => !candidate.IsAbstractClass)
+                    .Where(candidate => implementation.Name.Contains(candidate.GetInterfaceName()))
+                    .Where(candidate => !candidate.IsInSameNamespaceAs<object>(includeSubnamespaces: true))
             );
         }
     }

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceSelector.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceSelector.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace ZCrew.Extensions.DependencyInjection.Registration;
 
@@ -9,6 +10,11 @@ namespace ZCrew.Extensions.DependencyInjection.Registration;
 ///     (e.g. <c>AsSelf().AsAllInterfaces()</c>): each returns a new <see cref="ServiceSelector"/> and accumulates
 ///     the distinct service types, in-order.
 /// </summary>
+[UnconditionalSuppressMessage(
+    "Trimming",
+    "IL2067:Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source value must declare at least the same requirements as those declared on the target location it is assigned to",
+    Justification = Aot.Justification
+)]
 public class ServiceSelector : ServiceKeySelector
 {
     private readonly IEnumerable<Service>? services;

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceSelectorExtensions.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ServiceSelectorExtensions.cs
@@ -1,8 +1,24 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace ZCrew.Extensions.DependencyInjection.Registration;
 
 /// <summary>
 ///     Extensions for the <see cref="ServiceSelector"/> type to extend existing functionality with convenient helpers.
 /// </summary>
+/// <remarks>
+///     This API is not compatible with trimming or native AOT; see <see cref="Classes"/>. The suppressions below cover
+///     every part of this type, including the other <c>ServiceSelectorExtensions.*.cs</c> files.
+/// </remarks>
+[UnconditionalSuppressMessage(
+    "Trimming",
+    "IL2067:Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source value must declare at least the same requirements as those declared on the target location it is assigned to",
+    Justification = Aot.Justification
+)]
+[UnconditionalSuppressMessage(
+    "Trimming",
+    "IL2070:'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The generic parameter of the source method does not have matching annotations",
+    Justification = Aot.Justification
+)]
 public static partial class ServiceSelectorExtensions
 {
     extension(ServiceSelector selector)

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/TypeFilter.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/TypeFilter.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace ZCrew.Extensions.DependencyInjection.Registration;
 
 /// <summary>
@@ -6,6 +8,11 @@ namespace ZCrew.Extensions.DependencyInjection.Registration;
 ///     <c>BasedOn</c> methods. Maintains an immutable chain: each filter method returns a new <see cref="TypeFilter"/>
 ///     instance. When the stage is skipped, all types pass through unfiltered.
 /// </summary>
+[UnconditionalSuppressMessage(
+    "Trimming",
+    "IL2067:Target parameter argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The source value must declare at least the same requirements as those declared on the target location it is assigned to",
+    Justification = Aot.Justification
+)]
 public class TypeFilter : ServiceSelector
 {
     private static readonly IEnumerable<Type> DefaultBases = [typeof(object)];

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/Types.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/Types.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -8,12 +9,17 @@ namespace ZCrew.Extensions.DependencyInjection.Registration;
 ///     static factory methods to begin a registration chain from an assembly or a collection of types without any
 ///     type-kind filter.
 /// </summary>
+/// <remarks>
+///     This API is not compatible with trimming or native AOT. Use the <c>[Service]</c> source generator
+///     (<c>Services.FromThisAssembly()</c>) or <see cref="Service.From(Type)"/> instead.
+/// </remarks>
 public static class Types
 {
     /// <summary>
     ///     Begins registration from the specified collection of types.
     /// </summary>
     /// <param name="types">The types to select from.</param>
+    [RequiresUnreferencedCode(Classes.RequiresUnreferencedCodeMessage)]
     public static TypeFilter From(IEnumerable<Type> types)
     {
         ArgumentNullException.ThrowIfNull(types);
@@ -24,6 +30,7 @@ public static class Types
     ///     Begins registration from the specified types.
     /// </summary>
     /// <param name="types">The types to select from.</param>
+    [RequiresUnreferencedCode(Classes.RequiresUnreferencedCodeMessage)]
     public static TypeFilter From(params Type[] types)
     {
         ArgumentNullException.ThrowIfNull(types);
@@ -34,6 +41,7 @@ public static class Types
     ///     Begins registration by scanning the specified assembly for all types.
     /// </summary>
     /// <param name="assembly">The assembly to scan.</param>
+    [RequiresUnreferencedCode(Classes.RequiresUnreferencedCodeMessage)]
     public static AssemblyTypeSelector FromAssembly(Assembly assembly)
     {
         ArgumentNullException.ThrowIfNull(assembly);
@@ -44,6 +52,7 @@ public static class Types
     ///     Begins registration by scanning the assembly containing the specified type.
     /// </summary>
     /// <param name="type">A type whose containing assembly will be scanned.</param>
+    [RequiresUnreferencedCode(Classes.RequiresUnreferencedCodeMessage)]
     public static AssemblyTypeSelector FromAssemblyContaining(Type type)
     {
         ArgumentNullException.ThrowIfNull(type);
@@ -54,6 +63,7 @@ public static class Types
     ///     Begins registration by scanning the assembly containing <typeparamref name="T"/>.
     /// </summary>
     /// <typeparam name="T">A type whose containing assembly will be scanned.</typeparam>
+    [RequiresUnreferencedCode(Classes.RequiresUnreferencedCodeMessage)]
     public static AssemblyTypeSelector FromAssemblyContaining<T>()
     {
         return FromAssemblyContaining(typeof(T));
@@ -62,6 +72,7 @@ public static class Types
     /// <summary>
     ///     Begins registration by scanning the calling assembly for all types.
     /// </summary>
+    [RequiresUnreferencedCode(Classes.RequiresUnreferencedCodeMessage)]
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static AssemblyTypeSelector FromThisAssembly()
     {

--- a/src/ZCrew.Extensions.DependencyInjection.Registration/ZCrew.Extensions.DependencyInjection.Registration.csproj
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/ZCrew.Extensions.DependencyInjection.Registration.csproj
@@ -3,6 +3,10 @@
     <ProjectReference Include="../ZCrew.Extensions.DependencyInjection/ZCrew.Extensions.DependencyInjection.csproj" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
   <!-- NuGet package metadata -->
   <PropertyGroup>
     <PackageTags>dependency-injecting;scanning;registration;castle;windsor</PackageTags>

--- a/src/ZCrew.Extensions.DependencyInjection/DecoratorServiceDescriptor.cs
+++ b/src/ZCrew.Extensions.DependencyInjection/DecoratorServiceDescriptor.cs
@@ -18,7 +18,11 @@ internal class DecoratorServiceDescriptor
     /// <param name="serviceType">The <see cref="Type" /> of the service.</param>
     /// <param name="decoratorType">The decorator <see cref="Type" /> implementing the service.</param>
     /// <param name="lifetime">The <see cref="ServiceLifetime" /> of the service.</param>
-    public DecoratorServiceDescriptor(Type serviceType, Type decoratorType, ServiceLifetime? lifetime)
+    public DecoratorServiceDescriptor(
+        Type serviceType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type decoratorType,
+        ServiceLifetime? lifetime
+    )
         : this(serviceType, null, decoratorType, lifetime) { }
 
     /// <summary>
@@ -32,7 +36,7 @@ internal class DecoratorServiceDescriptor
     public DecoratorServiceDescriptor(
         Type serviceType,
         object? serviceKey,
-        Type decoratorType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type decoratorType,
         ServiceLifetime? lifetime
     )
         : this(serviceType, serviceKey, lifetime)

--- a/src/ZCrew.Extensions.DependencyInjection/TypeExtensions.cs
+++ b/src/ZCrew.Extensions.DependencyInjection/TypeExtensions.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+using System.Diagnostics.CodeAnalysis;
 
 namespace ZCrew.Extensions.DependencyInjection;
 
@@ -8,6 +8,11 @@ namespace ZCrew.Extensions.DependencyInjection;
 /// </summary>
 public static partial class TypeExtensions
 {
+    private const string InterfaceWalkJustification =
+        "Type.GetInterfaces() returns the flattened interface closure, so each element's own interfaces are already "
+        + "part of the preserved set. If one were trimmed away, the only effect is that an inherited interface is not "
+        + "removed and the type is registered against it as well.";
+
     extension(Type type)
     {
         /// <summary>
@@ -17,31 +22,6 @@ public static partial class TypeExtensions
         public bool IsAbstractClass
         {
             get => type is { IsAbstract: true, IsInterface: false };
-        }
-
-        /// <summary>
-        ///     Returns the type itself, all classes the current type extends, and all interfaces the current type
-        ///     implements.
-        /// </summary>
-        /// <returns>The list of all types the current type represents.</returns>
-        public IEnumerable<Type> GetTypes()
-        {
-            // Every type is itself
-            yield return type;
-
-            // And all base types
-            var baseType = type.BaseType;
-            while (baseType != null)
-            {
-                yield return baseType;
-                baseType = baseType.BaseType;
-            }
-
-            // And all interfaces
-            foreach (var @interface in type.GetInterfaces())
-            {
-                yield return @interface;
-            }
         }
 
         /// <summary>
@@ -133,6 +113,49 @@ public static partial class TypeExtensions
         }
 
         /// <summary>
+        ///     Returns the name without any generic arity.
+        /// </summary>
+        /// <returns>The name of the type without the generic arity.</returns>
+        /// <example>
+        ///     <see cref="List{T}"/> would be return the string <c>"List"</c>.
+        /// </example>
+        public string GetNonGenericName()
+        {
+            var backtick = type.Name.IndexOf('`');
+            return backtick > 0 ? type.Name[..backtick] : type.Name;
+        }
+    }
+
+    // Members that walk the interface hierarchy. The receiver keeps its interfaces when trimming so that
+    // Type.GetInterfaces() still returns the full set.
+    extension([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type)
+    {
+        /// <summary>
+        ///     Returns the type itself, all classes the current type extends, and all interfaces the current type
+        ///     implements.
+        /// </summary>
+        /// <returns>The list of all types the current type represents.</returns>
+        public IEnumerable<Type> GetTypes()
+        {
+            // Every type is itself
+            yield return type;
+
+            // And all base types
+            var baseType = type.BaseType;
+            while (baseType != null)
+            {
+                yield return baseType;
+                baseType = baseType.BaseType;
+            }
+
+            // And all interfaces
+            foreach (var @interface in type.GetInterfaces())
+            {
+                yield return @interface;
+            }
+        }
+
+        /// <summary>
         ///     Returns the most-derived (top-level) interfaces implemented by the type, excluding interfaces that are
         ///     inherited by other interfaces the type implements.
         /// </summary>
@@ -147,6 +170,18 @@ public static partial class TypeExtensions
         ///     <c>IUserRepository</c>, because <c>IRepository</c> is already inherited by
         ///     <c>IUserRepository</c>.
         /// </example>
+        // IL2075 is the analyzer's code for this and IL2065 is ILLink's; both are needed or the warning
+        // reappears in consumers' publish output.
+        [UnconditionalSuppressMessage(
+            "Trimming",
+            "IL2075:'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method",
+            Justification = InterfaceWalkJustification
+        )]
+        [UnconditionalSuppressMessage(
+            "Trimming",
+            "IL2065:Value passed to implicit 'this' parameter of method can not be statically determined",
+            Justification = InterfaceWalkJustification
+        )]
         public IEnumerable<Type> GetTopLevelInterfaces()
         {
             var interfaces = type.GetInterfaces();
@@ -161,19 +196,6 @@ public static partial class TypeExtensions
             }
 
             return topLevel;
-        }
-
-        /// <summary>
-        ///     Returns the name without any generic arity.
-        /// </summary>
-        /// <returns>The name of the type without the generic arity.</returns>
-        /// <example>
-        ///     <see cref="List{T}"/> would be return the string <c>"List"</c>.
-        /// </example>
-        public string GetNonGenericName()
-        {
-            var backtick = type.Name.IndexOf('`');
-            return backtick > 0 ? type.Name[..backtick] : type.Name;
         }
 
         /// <summary>
@@ -203,13 +225,31 @@ public static partial class TypeExtensions
         ///     generic type definition so the DI container can resolve them.
         /// </summary>
         /// <param name="baseTypes">The base types to match against.</param>
+        [UnconditionalSuppressMessage(
+            "Trimming",
+            "IL2072:'target parameter' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method",
+            Justification = "The interfaces come from the receiver's preserved interface closure; see "
+                + "GetTopLevelInterfaces for why walking them further is safe."
+        )]
         public IEnumerable<Type> GetTopLevelInterfacesMatchingBaseTypes(IEnumerable<Type> baseTypes)
         {
             var matches = new HashSet<Type>();
             var baseTypeArray = baseTypes.ToArray();
             foreach (var topLevelInterface in type.GetTopLevelInterfaces())
             {
-                if (!baseTypeArray.Any(baseType => topLevelInterface.IsBasedOn(baseType)))
+                // Looped rather than baseTypeArray.Any(...): a lambda calling the annotated IsBasedOn becomes a
+                // delegate the trimmer can't follow (IL2111).
+                var matchesBaseType = false;
+                foreach (var baseType in baseTypeArray)
+                {
+                    if (topLevelInterface.IsBasedOn(baseType))
+                    {
+                        matchesBaseType = true;
+                        break;
+                    }
+                }
+
+                if (!matchesBaseType)
                 {
                     continue;
                 }

--- a/src/ZCrew.Extensions.DependencyInjection/ZCrew.Extensions.DependencyInjection.csproj
+++ b/src/ZCrew.Extensions.DependencyInjection/ZCrew.Extensions.DependencyInjection.csproj
@@ -1,4 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
 
   <!-- NuGet package metadata -->
   <PropertyGroup>


### PR DESCRIPTION
Add in support for AOT - flagging the `Types` and `Classes` entry points as AOT-incompatible; and flagging `Services` and `Service.From` as AOT-compatible.

Internally some changes were necessary that may impact the ability to use some extension methods with trimming. Future improvements could be made, especially if they can allow further trimming or reducing warnings on invalid cases.

Closes #73