### PR TITLE
#77 - Make generic type filter methods public

### DIFF
--- a/src/ZCrew.Extensions.DependencyInjection.Registration/TypeFilterExtensions.Generic.cs
+++ b/src/ZCrew.Extensions.DependencyInjection.Registration/TypeFilterExtensions.Generic.cs
@@ -18,7 +18,7 @@ public static partial class TypeFilterExtensions
         ///     This is often implied if using other generic methods like: <see cref="GenericTypeDefinitions"/> or
         ///     <see cref="ConstructedGenericTypes"/>, so this can be skipped when calling those other methods.
         /// </remarks>
-        TypeFilter GenericTypes()
+        public TypeFilter GenericTypes()
         {
             return typeFilter.Where(type => type.IsGenericType);
         }
@@ -40,7 +40,7 @@ public static partial class TypeFilterExtensions
         ///     <see langword="true"/>. This means that <see cref="GenericTypeDefinitions"/> and
         ///     <see cref="ConstructedGenericTypes"/> are mutually exclusive and will not select the same types.
         /// </remarks>
-        TypeFilter GenericTypeDefinitions()
+        public TypeFilter GenericTypeDefinitions()
         {
             return typeFilter.Where(type => type.IsGenericTypeDefinition);
         }
@@ -62,7 +62,7 @@ public static partial class TypeFilterExtensions
         ///     <see langword="true"/>. This means that <see cref="GenericTypeDefinitions"/> and
         ///     <see cref="ConstructedGenericTypes"/> are mutually exclusive and will not select the same types.
         /// </remarks>
-        TypeFilter ConstructedGenericTypes()
+        public TypeFilter ConstructedGenericTypes()
         {
             return typeFilter.Where(type => type.IsConstructedGenericType);
         }

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesGenericFilterTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesGenericFilterTests.cs
@@ -1,0 +1,226 @@
+using Fixtures.SmallProject.Application.Pipelines;
+using Fixtures.SmallProject.Application.Services;
+using Fixtures.SmallProject.Domain.Entities;
+using Fixtures.SmallProject.Domain.Repositories;
+using Fixtures.SmallProject.Infrastructure.Caching;
+using Fixtures.SmallProject.Infrastructure.Persistence;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests.ClassesTests;
+
+public class ClassesGenericFilterTests
+{
+    [Fact]
+    public void GenericTypes_WithMixedTypes_ShouldFilterToGenericTypes()
+    {
+        // Act
+        var result = Classes
+            .From(
+                typeof(InMemoryRepository<>),
+                typeof(InMemoryRepository<Customer>),
+                typeof(CustomerService),
+                typeof(SqlCustomerRepository)
+            )
+            .GenericTypes()
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(InMemoryRepository<>), registeredTypes);
+        Assert.Contains(typeof(InMemoryRepository<Customer>), registeredTypes);
+        Assert.DoesNotContain(typeof(CustomerService), registeredTypes);
+        Assert.DoesNotContain(typeof(SqlCustomerRepository), registeredTypes);
+    }
+
+    [Fact]
+    public void GenericTypes_WithNoGenericTypes_ShouldReturnEmpty()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(CustomerService), typeof(OrderService))
+            .GenericTypes()
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GenericTypes_FromAssembly_ShouldExcludeNonGenericClasses()
+    {
+        // Act
+        var result = Classes.FromAssemblyContaining<CustomerService>().GenericTypes().AsSelf().ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(InMemoryRepository<>), registeredTypes);
+        Assert.Contains(typeof(SqlRepository<>), registeredTypes);
+        Assert.Contains(typeof(InMemoryCacheProvider<>), registeredTypes);
+        Assert.DoesNotContain(typeof(CustomerService), registeredTypes);
+        Assert.DoesNotContain(typeof(OrderValidationStep), registeredTypes);
+    }
+
+    [Fact]
+    public void GenericTypeDefinitions_WithMixedGenerics_ShouldFilterToOpenGenerics()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(InMemoryRepository<>), typeof(InMemoryRepository<Customer>), typeof(CustomerService))
+            .GenericTypeDefinitions()
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(InMemoryRepository<>), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void GenericTypeDefinitions_FromAssembly_ShouldFilterToOpenGenerics()
+    {
+        // Act
+        var result = Classes
+            .FromAssemblyContaining<CustomerService>()
+            .GenericTypeDefinitions()
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(InMemoryRepository<>), registeredTypes);
+        Assert.Contains(typeof(LoggingStep<>), registeredTypes);
+        Assert.DoesNotContain(typeof(SqlCustomerRepository), registeredTypes);
+    }
+
+    [Fact]
+    public void ConstructedGenericTypes_WithMixedGenerics_ShouldFilterToClosedGenerics()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(InMemoryRepository<>), typeof(InMemoryRepository<Customer>), typeof(CustomerService))
+            .ConstructedGenericTypes()
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(InMemoryRepository<Customer>), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void ConstructedGenericTypes_WithClosedGeneric_ShouldRegisterClosedType()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(InMemoryRepository<Customer>))
+            .ConstructedGenericTypes()
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(InMemoryRepository<Customer>), descriptor.ServiceType);
+        Assert.Equal(typeof(InMemoryRepository<Customer>), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void ConstructedGenericTypes_FromAssembly_ShouldReturnEmpty()
+    {
+        // Act
+        var result = Classes
+            .FromAssemblyContaining<CustomerService>()
+            .ConstructedGenericTypes()
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GenericTypeDefinitions_WhenChainedWithConstructedGenericTypes_ShouldReturnEmpty()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(InMemoryRepository<>), typeof(InMemoryRepository<Customer>))
+            .GenericTypeDefinitions()
+            .ConstructedGenericTypes()
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GenericTypes_WhenChainedWithGenericTypeDefinitions_ShouldFilterToOpenGenerics()
+    {
+        // Act
+        var result = Classes
+            .From(typeof(InMemoryRepository<>), typeof(InMemoryRepository<Customer>), typeof(CustomerService))
+            .GenericTypes()
+            .GenericTypeDefinitions()
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(InMemoryRepository<>), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void GenericTypeDefinitions_WhenCombinedWithBasedOn_ShouldApplyBoth()
+    {
+        // Act
+        var result = Classes
+            .FromAssemblyContaining<CustomerService>()
+            .BasedOn(typeof(IRepository<>))
+            .GenericTypeDefinitions()
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(InMemoryRepository<>), registeredTypes);
+        Assert.Contains(typeof(SqlRepository<>), registeredTypes);
+        Assert.DoesNotContain(typeof(SqlCustomerRepository), registeredTypes);
+        Assert.DoesNotContain(typeof(LoggingStep<>), registeredTypes);
+    }
+
+    [Fact]
+    public void GenericTypeDefinitions_WhenCombinedWithNameEndsWith_ShouldApplyBoth()
+    {
+        // Act
+        var result = Classes
+            .FromAssemblyContaining<CustomerService>()
+            .NameEndsWith("Repository")
+            .GenericTypeDefinitions()
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(InMemoryRepository<>), registeredTypes);
+        Assert.Contains(typeof(SqlRepository<>), registeredTypes);
+        Assert.DoesNotContain(typeof(SqlCustomerRepository), registeredTypes);
+        Assert.DoesNotContain(typeof(InMemoryCacheProvider<>), registeredTypes);
+    }
+
+    [Fact]
+    public void GenericTypes_WhenEnumeratedWithoutTerminalMethod_ShouldDefaultToSelfRegistration()
+    {
+        // Arrange
+        var filter = Classes.From(typeof(InMemoryRepository<>), typeof(CustomerService)).GenericTypes();
+
+        // Act
+        var result = filter.ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(InMemoryRepository<>), descriptor.ServiceType);
+        Assert.Equal(typeof(InMemoryRepository<>), descriptor.ImplementationType);
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+    }
+}

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesNameEndsWithTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesNameEndsWithTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Fixtures.SmallProject.Application.Services;
 using Fixtures.SmallProject.Infrastructure.External;
 using Fixtures.SmallProject.Infrastructure.Persistence;
@@ -72,6 +73,39 @@ public class ClassesNameEndsWithTests
         // Assert
         var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
         Assert.DoesNotContain(typeof(CustomerService), registeredTypes);
+    }
+
+    [Fact]
+    public void NameEndsWith_WithInvariantCulture_ShouldMatchIgnoringCase()
+    {
+        // Act
+        var result = Classes
+            .FromAssemblyContaining<CustomerService>()
+            .NameEndsWith("service", ignoreCase: true, CultureInfo.InvariantCulture)
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(CustomerService), registeredTypes);
+        Assert.Contains(typeof(OrderService), registeredTypes);
+        Assert.DoesNotContain(typeof(SqlCustomerRepository), registeredTypes);
+    }
+
+    [Fact]
+    public void NameEndsWith_WithNullCulture_ShouldUseCurrentCulture()
+    {
+        // Act
+        var result = Classes
+            .FromAssemblyContaining<CustomerService>()
+            .NameEndsWith("Service", ignoreCase: false, cultureInfo: null)
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(CustomerService), registeredTypes);
+        Assert.DoesNotContain(typeof(SqlCustomerRepository), registeredTypes);
     }
 
     [Fact]

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesNamespaceFilterTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/ClassesTests/ClassesNamespaceFilterTests.cs
@@ -126,6 +126,32 @@ public class ClassesNamespaceFilterTests
     }
 
     [Fact]
+    public void InNamespace_WithNullNamespace_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        var filter = Classes.From(typeof(CustomerService));
+
+        // Act
+        var act = () => filter.InNamespace(null!);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(act);
+    }
+
+    [Fact]
+    public void InSameNamespaceAs_WithNullType_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        var filter = Classes.From(typeof(CustomerService));
+
+        // Act
+        var act = () => filter.InSameNamespaceAs((Type)null!);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(act);
+    }
+
+    [Fact]
     public void InSameNamespaceAs_AfterWhere_WithGenericAndSubnamespaces_ShouldFilterCorrectly()
     {
         // Act - .Where() produces a TypeFilter, ensuring TypeFilter.InSameNamespaceAs<T>(bool) is invoked

--- a/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesGenericFilterTests.cs
+++ b/tests/ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests/TypesTests/TypesGenericFilterTests.cs
@@ -1,0 +1,90 @@
+using Fixtures.SmallProject.Application.Pipelines;
+using Fixtures.SmallProject.Application.Services;
+using Fixtures.SmallProject.Domain.Entities;
+using Fixtures.SmallProject.Domain.Repositories;
+using Fixtures.SmallProject.Domain.Services;
+using Fixtures.SmallProject.Infrastructure.Persistence;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ZCrew.Extensions.DependencyInjection.Registration.IntegrationTests.TypesTests;
+
+public class TypesGenericFilterTests
+{
+    [Fact]
+    public void GenericTypes_WithInterfaces_ShouldIncludeGenericInterfaces()
+    {
+        // Act
+        var result = Types.FromAssemblyContaining<CustomerService>().GenericTypes().AsSelf().ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(IRepository<>), registeredTypes);
+        Assert.Contains(typeof(IValidator<>), registeredTypes);
+        Assert.Contains(typeof(IPipelineBehavior<,>), registeredTypes);
+        Assert.Contains(typeof(InMemoryRepository<>), registeredTypes);
+        Assert.DoesNotContain(typeof(ICustomerService), registeredTypes);
+        Assert.DoesNotContain(typeof(CustomerService), registeredTypes);
+    }
+
+    [Fact]
+    public void GenericTypes_WithStructsAndEnums_ShouldExcludeNonGenerics()
+    {
+        // Act
+        var result = Types
+            .From(typeof(Currency), typeof(OrderStatus), typeof(IRepository<>))
+            .GenericTypes()
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(IRepository<>), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void GenericTypeDefinitions_WithTypeNestedInGenericType_ShouldMatch()
+    {
+        // Act
+        var result = Types
+            .FromAssemblyContaining<CustomerService>()
+            .GenericTypeDefinitions()
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var registeredTypes = result.Select(d => d.ImplementationType).ToArray();
+        Assert.Contains(typeof(Pipeline<>.IStep), registeredTypes);
+        Assert.DoesNotContain(typeof(OrderValidationStep), registeredTypes);
+    }
+
+    [Fact]
+    public void ConstructedGenericTypes_WithClosedInterface_ShouldFilterToClosedGenerics()
+    {
+        // Act
+        var result = Types
+            .From(typeof(IRepository<>), typeof(IRepository<Customer>), typeof(ICustomerRepository))
+            .ConstructedGenericTypes()
+            .AsSelf()
+            .ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(IRepository<Customer>), descriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void GenericTypes_WhenEnumeratedWithoutTerminalMethod_ShouldDefaultToSelfRegistration()
+    {
+        // Arrange
+        var filter = Types.From(typeof(IRepository<>), typeof(ICustomerRepository)).GenericTypes();
+
+        // Act
+        var result = filter.ToServiceCollection();
+
+        // Assert
+        var descriptor = Assert.Single(result);
+        Assert.Equal(typeof(IRepository<>), descriptor.ServiceType);
+        Assert.Equal(typeof(IRepository<>), descriptor.ImplementationType);
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+    }
+}


### PR DESCRIPTION
These were missed in the conversion from interfaces to classes. 

Added tests.

Closes #77